### PR TITLE
Add benchmarks

### DIFF
--- a/scripts/gdsio.py
+++ b/scripts/gdsio.py
@@ -2,41 +2,53 @@
 A gdsio-wrapper, invoking it repeatedly with variying arguments
 ===============================================================
 
-TODO:
-
-* Add parameters for bin, mounpint and repetitions
-* Add a generic way to pass gdsio arguments
-
 Retargetable: True
 ------------------
 """
 
-import errno
-import logging as log
+from argparse import ArgumentParser
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--bin", type=str, default="/usr/local/cuda/gds/tools/gdsio")
+    parser.add_argument("--dir", type=str, default="/mnt/gds01/gds_dir")
+    parser.add_argument("--nthreads", type=int, default=1)
+    parser.add_argument("--gpu_index", type=int, default=0)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument(
+        "--mode",
+        type=int,
+        default=2,
+        help="read(0), write(1), randread(2), randwrite(3)",
+    )
+    parser.add_argument("--iosize", type=str, default="4K")
+    parser.add_argument(
+        "--xfer_types",
+        type=int,
+        default=[0, 1, 2, 3, 4, 5, 6, 7],
+        nargs="+",
+        help="GPU_DIRECT(0), CPU_ONLY(1), CPU_GPU(2), CPU_ASYNC_GPU(3), CPU_CACHED_GPU(4), GPU_DIRECT_ASYNC(5), GPU_BATCH(6), GPU_BATCH_STREAM(7)",
+    )
 
 
 def main(args, cijoe):
-    """Copies the file at args.src on the local machine to args.dst on the remote machine"""
-
-    bin = "/usr/local/cuda/gds/tools/gdsio"
-    mountpoint = "/mnt/gds01/gds_dir"
-    gpu_index = 0
-    nthreads = 1
+    bin = args.bin
+    dir = args.dir
+    gpu_index = args.gpu_index
+    nthreads = args.nthreads
     filesize = "8G"
-    iosize = "4K"  # Size of each IO
+    iosize = args.iosize  # Size of each IO
     runtime = 10  # Runtime in seconds
-    mode = 2  # read(0) | write(1) | randread(2) | randwrite(3)
-    xfer_type = 0
-    xfer_types = list(range(8))  # GPUD(0), CPUONLY(1), ... ,
 
-    cmd = f"{bin} -D {mountpoint} -d {gpu_index} -w {nthreads} -s {filesize} -i {iosize} -I 1 -x {xfer_type}"
+    # Precondition by creating the files
+    cmd = f"{bin} -D {dir} -d {gpu_index} -w {nthreads} -s {filesize} -i {iosize} -I 1 -x 0"
     err, _ = cijoe.run(cmd)
     if err:
         return 1
 
-    for xfer_type in xfer_types:
-        for rep in range(3):
-            cmd = f"{bin} -D {mountpoint} -d {gpu_index} -w {nthreads} -s {filesize} -i {iosize} -T {runtime} -I {mode} -x {xfer_type}"
+    for xfer_type in args.xfer_types:
+        cmd = f"{bin} -D {dir} -d {gpu_index} -w {nthreads} -s {filesize} -i {iosize} -T {runtime} -I {args.mode} -x {xfer_type}"
+        for rep in range(args.repetitions):
             err, _ = cijoe.run(cmd)
             if err:
                 return 1

--- a/scripts/sil.py
+++ b/scripts/sil.py
@@ -1,0 +1,60 @@
+"""
+A SIL-wrapper invoking it with arguments
+========================================
+
+Retargetable: True
+------------------
+"""
+
+from argparse import ArgumentParser, _StoreAction
+
+
+def add_args(parser: ArgumentParser):
+    class StringToBoolAction(_StoreAction):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values == "true")
+
+    parser.add_argument("--backends", type=str, default=["posix"], nargs="+")
+    parser.add_argument("--dataset", type=str, default="imagenetish")
+    parser.add_argument("--device", type=str, default="/dev/nvme1n1")
+    parser.add_argument("--bin", type=str, default="sil")
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--batches", type=int, default=1)
+    parser.add_argument("--gpu_nqueues", type=int, default=6)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument(
+        "--random", choices=["true", "false"], default=False, action=StringToBoolAction
+    )
+
+
+def get_opts(args, cijoe, backend):
+    mountpoint = cijoe.getconf("filesystems.dset.mountpoint")
+    out = ""
+    if backend == "posix":
+        if mountpoint:
+            out += f"--mnt {mountpoint} "
+        out += "--buffered "
+        return out
+    if backend == "gds":
+        if mountpoint:
+            out += f"--mnt {mountpoint} "
+        return out
+    if backend == "aisio":
+        out += f"--gpu-nqueues {args.gpu_nqueues} "
+        if args.random:
+            out += "--random "
+        return out
+
+
+def main(args, cijoe):
+    prefix = "echo 3 > /proc/sys/vm/drop_caches;"
+
+    for backend in args.backends:
+        opts = get_opts(args, cijoe, backend)
+        cmd = f"{prefix} {args.bin} {args.device} --data-dir {args.dataset} --batches {args.batches} --batch-size {args.batch_size} --backend {backend} {opts}"
+        for _ in range(args.repetitions):
+            err, _ = cijoe.run(cmd)
+        if err:
+            return 1
+
+    return 0

--- a/scripts/sil.py
+++ b/scripts/sil.py
@@ -48,10 +48,14 @@ def get_opts(args, cijoe, backend):
 
 def main(args, cijoe):
     prefix = "echo 3 > /proc/sys/vm/drop_caches;"
+    dataset = ""
+
+    if args.dataset:
+        dataset = f"--data-dir {args.dataset}"
 
     for backend in args.backends:
         opts = get_opts(args, cijoe, backend)
-        cmd = f"{prefix} {args.bin} {args.device} --data-dir {args.dataset} --batches {args.batches} --batch-size {args.batch_size} --backend {backend} {opts}"
+        cmd = f"{prefix} {args.bin} {args.device} {dataset} --batches {args.batches} --batch-size {args.batch_size} --backend {backend} {opts}"
         for _ in range(args.repetitions):
             err, _ = cijoe.run(cmd)
         if err:

--- a/tasks/benchmark_files.yaml
+++ b/tasks/benchmark_files.yaml
@@ -1,0 +1,67 @@
+doc: |
+  Run SIL benchmarks to evaluate performance with different datasets
+  ==================================================================
+
+  In this benchmark we are reading 3 different datasets: filesize8gib, tiktokish, imagenetish
+  with 3 different backends: POSIX, NVIDIA GDS, AiSIO
+
+  `device` should be adjusted to target the correct SSD.
+  `batch_size` and `batches` are appropriate for a H100 GPU, and should be adjusted according to hardware. 
+  
+  This assumes you already ran the tasks 'setup_aisio.yaml' and 'setup_datasets.yaml'
+  
+
+steps:
+- name: benchmark_filesize8gib_aisio
+  uses: sil
+  with: 
+    backends: ["aisio"]
+    dataset: "filesize8gib"
+    device: "/dev/libnvm0"
+    batch_size: 1
+    batches: 1
+
+- name: benchmark_filesize8gib_posix_gds
+  uses: sil
+  with: 
+    backends: ["posix", "gds"]
+    dataset: "filesize8gib"
+    device: "/dev/nvme1n1"
+    batch_size: 1
+    batches: 1
+
+- name: benchmark_tiktokish_aisio
+  uses: sil
+  with: 
+    backends: ["aisio"]
+    dataset: "tiktokish"
+    device: "/dev/libnvm0"
+    batch_size: 26
+    batches: 1
+
+- name: benchmark_tiktokish_posix_gds
+  uses: sil
+  with: 
+    backends: ["posix", "gds"]
+    dataset: "tiktokish"
+    device: "/dev/nvme1n1"
+    batch_size: 26
+    batches: 1
+  
+- name: benchmark_imagenetish_aisio
+  uses: sil
+  with: 
+    backends: ["aisio"]
+    dataset: "imagenetish"
+    device: "/dev/libnvm0"
+    batch_size: 4096
+    batches: 300
+
+- name: benchmark_imagenetish_posix_gds
+  uses: sil
+  with: 
+    backends: ["posix", "gds"]
+    dataset: "imagenetish"
+    device: "/dev/nvme1n1"
+    batch_size: 4096
+    batches: 300

--- a/tasks/benchmark_synthetic.yaml
+++ b/tasks/benchmark_synthetic.yaml
@@ -1,0 +1,40 @@
+doc: |
+  Run benchmarks to evaluate synthetic performance with GDS and AiSIO
+  ===================================================================
+
+  In this benchmark we are benchmarking random and sequential read using different tools:
+  `gdsio` (GDS), `sil` (AiSIO)
+
+  This assumes you already ran the task 'setup_aisio.yaml'
+  
+
+steps:
+- name: benchmark_aisio_seq
+  uses: sil
+  with:
+    backends: ["aisio"]
+    dataset: ""
+    device: "/dev/libnvm0"
+    batch_size: 16777216
+    random: false
+
+- name: benchmark_aisio_rand
+  uses: sil
+  with:
+    backends: ["aisio"]
+    dataset: ""
+    device: "/dev/libnvm0"
+    batch_size: 16777216
+    random: true
+
+- name: benchmark_gdsio_seq
+  uses: gdsio
+  with:
+    xfer_types: [0]
+    mode: [0]
+
+- name: benchmark_gdsio_rand
+  uses: gdsio
+  with:
+    xfer_types: [0]
+    mode: [2]


### PR DESCRIPTION
This adds a wrapper for SIL, arguments for GDSIO and two benchmarks: synthetic and file.

Potentially, we can add BaM `nvm-block-bench` to the synthetic benchmark 