### PR TITLE
fix(dmabuf): style and compile fixes for the nvstack and dmabuf tasks

### DIFF
--- a/configs/uio_dmabuf.toml
+++ b/configs/uio_dmabuf.toml
@@ -1,7 +1,6 @@
 [linux.source]
 pkg = "linux-source-6.8.0"
 
-
 [uio.patch]
-path = {{ local.env.HOME }}/git/aisio/patches
-name = uio-import-dma-buf-and-share-phys-addr-to-user.patch
+path = "{{ local.env.HOME }}/git/aisio/uio-dmabuf/patches"
+name = "uio-import-dma-buf-and-share-phys-addr-to-user.patch"

--- a/tasks/setup_nvstack.yaml
+++ b/tasks/setup_nvstack.yaml
@@ -94,7 +94,7 @@ steps:
     systemctl stop unattended-upgrades || true
     systemctl disable unattended-upgrades || true
     systemctl mask unattended-upgrades || true
-    apt remove unattended-upgrades || true
+    apt-get remove unattended-upgrades || true
 
 - name: packages
   run: |
@@ -107,6 +107,13 @@ steps:
     echo "blacklist nouveau" | tee /etc/modprobe.d/disable-nouveau.conf
     echo "options nouveau modeset=0" | tee -a /etc/modprobe.d/disable-nouveau.conf
     update-initramfs -u
+
+- name: ofed
+  run: |
+    wget -O workdir/ofed.tgz {{ config.nvidia.ofed.url }}
+    cd workdir; tar xzf ofed.tgz
+    cd workdir/MLNX*; ./mlnxofedinstall --with-nvmf --with-nfsrdma --enable-gds --add-kernel-support --dkms
+    update-initramfs -u -k $(uname -r)
 
 - name: reboot
   run: shutdown -r now
@@ -153,11 +160,11 @@ steps:
     wget -O workdir/cuda_keyring.deb {{ config.nvidia.keyring.url }}
     dpkg -i workdir/cuda_keyring.deb
     wget -O /etc/apt/preferences.d/cuda-repository-pin-600 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-ubuntu2404.pin
-    apt update
+    apt-get update
     
 - name: cuda
   run: |
-    apt-get install -y cuda-12-8
+    apt-get install -y cuda-toolkit-12-8
 
 # Setup CUDA for all interactive shells via '/etc/profile.d' and source this it explicitly for
 # 'root' via /root/.bashrc for non-interactive use of CUDA via e.g. ssh
@@ -184,28 +191,6 @@ steps:
 - name: nvidia_gds
   run: |
     apt-get install -y nvidia-gds-12-8
-
-- name: ofed
-  run: |
-    wget -O workdir/ofed.tgz {{ config.nvidia.ofed.url }}
-    cd workdir; tar xzf ofed.tgz
-    cd workdir/MLNX*; ./mlnxofedinstall --with-nvmf --with-nfsrdma --enable-gds --add-kernel-support --dkms
-    update-initramfs -u -k $(uname -r)
-
-- name: reboot_again
-  run: shutdown -r now
-
-- name: wait_for_down_again
-  uses: core.wait_for_transport
-  with:
-    state: down
-    timeout: 60
-
-- name: wait_for_up_again
-  uses: core.wait_for_transport
-  with:
-    state: up
-    timeout: 300
 
 - name: checkup
   run: |

--- a/tasks/setup_uio_dmabuf.yaml
+++ b/tasks/setup_uio_dmabuf.yaml
@@ -16,68 +16,66 @@ doc: |
       -c configs/uio_dmabuf.toml \
       tasks/setup_uio_dmabuf.yaml
 
-  
   Adjust transport.toml with the hostname and ssh-login info of the root user.
   Adjust uio_dmabuf.toml with the path to your aisio github repository on the host.
 
-
 steps:
-  - name: install_dependencies
-    run: |
-      apt-get -fy install build-essential libncurses-dev bison flex libssl-dev libelf-dev
+- name: install_dependencies
+  run: |
+    apt-get -fy install bison build-essential debhelper-compat flex libelf-dev libncurses-dev libssl-dev
+
+- name: fetch_kernel_source
+  run: |
+    apt-get -fy install {{ config.linux.source.pkg }}
+
+- name: decompress_source
+  run: |
+    cd /usr/src/{{ config.linux.source.pkg }}; tar -jxf {{ config.linux.source.pkg }}.tar.bz2  --strip-components=1
+
+- name: copy_patch
+  uses: core.put
+  with:
+    src: "{{ config.uio.patch.path }}/{{ config.uio.patch.name }}"
+    dst: /usr/src/{{ config.linux.source.pkg }}
+
+- name: apply_patch
+  run: |
+    cd /usr/src/{{ config.linux.source.pkg }}; git apply --reject {{ config.uio.patch.name }}
+
+- name: get_config
+  run: |
+    cp /boot/config-$(uname -r) /usr/src/{{ config.linux.source.pkg }}/.config
+
+- name: configure
+  run: |
+    cd /usr/src/{{ config.linux.source.pkg }}; scripts/config --disable DEBUG_INFO
+    cd /usr/src/{{ config.linux.source.pkg }}; scripts/config --set-str SYSTEM_TRUSTED_KEYS ""
+    cd /usr/src/{{ config.linux.source.pkg }}; scripts/config --set-str SYSTEM_REVOCATION_KEYS ""
+    cd /usr/src/{{ config.linux.source.pkg }}; scripts/config --disable MODULE_SIG 
+
+- name: prepare
+  run: |
+    cd /usr/src/{{ config.linux.source.pkg }}; make olddefconfig scripts prepare modules_prepare
+
+- name: build
+  run: |
+    cd /usr/src/{{ config.linux.source.pkg }}; make -j $(nproc) bindeb-pkg LOCALVERSION=-dmabuf
+
+- name: install
+  run: |
+    cd /usr/src/{{ config.linux.source.pkg }}; dpkg -i ../*.deb
+
+- name: reboot
+  run: shutdown -r now
+
+- name: wait_down
+  uses: core.wait_for_transport
+  with:
+    state: down
+    timeout: 60
   
-  - name: fetch_kernel_source
-    run: |
-      apt-get -fy install {{ config.linux.source.pkg }}
-
-  - name: decompress_source
-    run: |
-      cd /usr/src/{{ config.linux.source.pkg }}; tar -jxf {{ config.linux.source.pkg }}.tar.bz2  --strip-components=1
-
-  - name: copy_patch
-    uses: core.put
-    with:
-      src: "{{ config.uio.patch.path }}/{{ config.uio.patch.name }}"
-      dst: /usr/src/{{ config.linux.source.pkg }}
-
-  - name: apply_patch
-    run: |
-      cd /usr/src/{{ config.linux.source.pkg }}; git apply --reject {{ config.uio.patch.name }}
-
-  - name: get_config
-    run: |
-      cp /boot/config-$(uname -r) /usr/src/{{ config.linux.source.pkg }}/.config
-
-  - name: configure
-    run: |
-      cd /usr/src/{{ config.linux.source.pkg }}; scripts/config --disable DEBUG_INFO; \
-        scripts/config --set-str SYSTEM_TRUSTED_KEYS ""; \
-        scripts/config --set-str SYSTEM_REVOCATION_KEYS ""; \
-        scripts/config --disable MODULE_SIG 
-
-  - name: prepare
-    run: |
-      cd /usr/src/{{ config.linux.source.pkg }}; make olddefconfig scripts prepare modules_prepare
-  
-  - name: build
-    run: |
-      cd /usr/src/{{ config.linux.source.pkg }}; make -j $(nproc) bindeb-pkg LOCALVERSION=-dmabuf
-
-  - name: install
-    run: |
-      cd /usr/src/{{ config.linux.source.pkg }}; dpkg -i ../*.deb
-  
-  - name: reboot
-    run: shutdown -r now
-
-  - name: wait_down
-    uses: core.wait_for_transport
-    with:
-      state: down
-      timeout: 60
-    
-  - name: wait_up
-    uses: core.wait_for_transport
-    with:
-      state: up
-      timeout: 300
+- name: wait_up
+  uses: core.wait_for_transport
+  with:
+    state: up
+    timeout: 300


### PR DESCRIPTION
- Reduced linebreaks when multiple in a row were inserted.
- Reduced indentation for yaml file to match our style.
- Fixed compile-errors for TOML files.
- Tested the setup_nvstack and setup_uio_dmabuf tasks from scratch and added necessary changes.
- For the "configure" step in dmabuf workflow, I removed the multi-line command, as this is not supported in cijoe. I have created an issue for adding support: https://github.com/refenv/cijoe/issues/199