### PR TITLE
fix(setup): add parallel to provisioning

### DIFF
--- a/tasks/setup_nvstack.yaml
+++ b/tasks/setup_nvstack.yaml
@@ -99,7 +99,7 @@ steps:
 - name: packages
   run: |
     apt-get -qy update && apt-get -qy upgrade
-    apt-get -qy install build-essential linux-headers-$(uname -r) wget git htop vim cmake stress-ng
+    apt-get -qy install build-essential linux-headers-$(uname -r) wget git htop vim cmake stress-ng parallel
     apt-get -qy autoremove
 
 - name: blacklist_nouveau


### PR DESCRIPTION
GNU parallel is required for setting up the datasets. Make sure it is installed.