### PR TITLE
feat(homi): add backend config option

### DIFF
--- a/homi/config/homi.conf.in
+++ b/homi/config/homi.conf.in
@@ -6,3 +6,12 @@ log_level = 2
 # Devices is a list of dev URIs as strings, e.g.
 # devices = [ "/dev/nvme0n1", "/dev/nvme1n1" ]
 devices = [ ]
+
+# Backends: aisio, posix, etc.
+backend = "aisio"
+
+# Number of GPU queues (only relevant with aisio backend)
+gpu_nqueues = 128
+
+# Number of GPU threadblocks (only relevant with aisio backend)
+gpu_tbsize = 64

--- a/homi/include/homi_device.h
+++ b/homi/include/homi_device.h
@@ -1,0 +1,7 @@
+enum homi_backend {
+	HOMI_BACKEND_AISIO,
+	HOMI_BACKEND_POSIX,
+};
+
+void
+homi_device_set_backend(struct homi_opts *opts);

--- a/homi/include/homi_opts.h
+++ b/homi/include/homi_opts.h
@@ -4,6 +4,9 @@ struct homi_opts {
 	int log_level;
 	int ndevs;
 	char (*dev_uris)[HOMI_DEVURI_MAXLEN];
+	int backend;
+	int gpu_nqueues;
+	int gpu_tbsize;
 };
 
 /**

--- a/homi/meson.build
+++ b/homi/meson.build
@@ -19,6 +19,7 @@ sources = files(
   'src/homi.c',
   'src/homi_log.c',
   'src/homi_opts.c',
+  'src/homi_device.c',
 )
 
 include_dirs = include_directories('include')

--- a/homi/src/homi.c
+++ b/homi/src/homi.c
@@ -10,7 +10,7 @@
 
 #include <homi_log.h>
 #include <homi_opts.h>
-
+#include <homi_device.h>
 
 volatile sig_atomic_t stop = 0;
 
@@ -50,6 +50,8 @@ initialize(struct homi_opts *opts)
 	for (int i = 0; i < opts->ndevs; i++) {
 		homi_log(LOG_NOTICE, "Device: %s", opts->dev_uris[i]);
 	}
+
+	homi_device_set_backend(opts);
 
 	return 0;
 }

--- a/homi/src/homi_device.c
+++ b/homi/src/homi_device.c
@@ -1,0 +1,24 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <homi_log.h>
+#include <homi_opts.h>
+#include <homi_device.h>
+
+void
+homi_device_set_backend(struct homi_opts *opts)
+{
+
+	// TODO: init backend here
+	switch (opts->backend)
+	{
+	case HOMI_BACKEND_AISIO:
+	case HOMI_BACKEND_POSIX:
+	default:
+		break;
+	}
+
+	return;
+}

--- a/homi/src/homi_opts.c
+++ b/homi/src/homi_opts.c
@@ -6,6 +6,7 @@
 
 #include <homi_log.h>
 #include <homi_opts.h>
+#include <homi_device.h>
 
 static int
 get_default_opts(struct homi_opts *opts)
@@ -20,6 +21,7 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 {
 	toml_result_t result;
 	toml_datum_t log_level, devices;
+	toml_datum_t backend, gpu_nqueues, gpu_tbsize;
 	int err = 0;
 
 	result = toml_parse_file_ex(config_file);
@@ -89,6 +91,44 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 
 		strcpy(opts->dev_uris[i], elem.u.s);
 	}
+
+	backend = toml_seek(result.toptab, "backend");
+
+	if (backend.type != TOML_STRING) {
+		homi_log(LOG_ERR, "Missing or invalid 'backend' property in config");
+		err = -EINVAL;
+		goto exit;
+	}
+
+	if (strcmp(backend.u.s, "aisio") == 0) {
+		opts->backend = HOMI_BACKEND_AISIO;
+
+		// Parse gpu_nqueues for aisio
+		gpu_nqueues = toml_seek(result.toptab, "gpu_nqueues");
+		if (gpu_nqueues.type != TOML_INT64) {
+			homi_log(LOG_WARNING, "Missing or invalid 'gpu_nqueues' in config, defaulting to 128.");
+			opts->gpu_nqueues = 128;
+		} else {
+			opts->gpu_nqueues = gpu_nqueues.u.int64;
+		}
+
+		// Parse gpu_tbsize for aisio
+		gpu_tbsize = toml_seek(result.toptab, "gpu_tbsize");
+		if (gpu_tbsize.type != TOML_INT64) {
+			homi_log(LOG_WARNING, "Missing or invalid 'gpu_tbsize' in config, defaulting to 64.");
+			opts->gpu_tbsize = 64;
+		} else {
+			opts->gpu_tbsize = gpu_tbsize.u.int64;
+		}
+	} else if (strcmp(backend.u.s, "posix") == 0) {
+		opts->backend = HOMI_BACKEND_POSIX;
+	} else {
+		homi_log(LOG_ERR, "Invalid backend: %s", backend.u.s);
+		goto exit;
+	}
+
+	homi_log(LOG_NOTICE, "homi backend set to %d, gpu_nqueues %d, gpu_tbsize %d",
+			opts->backend, opts->gpu_nqueues, opts->gpu_tbsize);
 
 exit:
 	toml_free(result);


### PR DESCRIPTION
parse backend, gpu_nqueues, gpu_tbsize from toml file
added files src/homi_device.c and include/homi_device.h

I wanted to make sure I'm on the right track, hence opened this small PR!