### PR TITLE
refactor(homi): rename homi to homid

### DIFF
--- a/homi/include/homi_log.h
+++ b/homi/include/homi_log.h
@@ -1,5 +1,0 @@
-void
-homi_log_set_level(int level);
-
-void
-homi_log(int level, const char *fmt, ...);

--- a/homi/include/homid_log.h
+++ b/homi/include/homid_log.h
@@ -1,0 +1,5 @@
+void
+homid_log_set_level(int level);
+
+void
+homid_log(int level, const char *fmt, ...);

--- a/homi/include/homid_opts.h
+++ b/homi/include/homid_opts.h
@@ -1,9 +1,9 @@
-#define HOMI_DEVURI_MAXLEN 256
+#define HOMID_DEVURI_MAXLEN 256
 
-struct homi_opts {
+struct homid_opts {
 	int log_level;
 	int ndevs;
-	char (*dev_uris)[HOMI_DEVURI_MAXLEN];
+	char (*dev_uris)[HOMID_DEVURI_MAXLEN];
 };
 
 /**
@@ -14,7 +14,7 @@ struct homi_opts {
  * - devices (array of strings)
  *
  * @param path Path to the configuration file
- * @param opts homi_opts struct that the configuration will be loaded into
+ * @param opts homid_opts struct that the configuration will be loaded into
  */
 int
-homi_opts_from_toml(char *path, struct homi_opts *opts);
+homid_opts_from_toml(char *path, struct homid_opts *opts);

--- a/homi/meson.build
+++ b/homi/meson.build
@@ -16,9 +16,9 @@ toml_dep = toml.get_variable('toml_dep')
 homi_dependencies = [toml_dep]
 
 sources = files(
-  'src/homi.c',
-  'src/homi_log.c',
-  'src/homi_opts.c',
+  'src/homid.c',
+  'src/homid_log.c',
+  'src/homid_opts.c',
 )
 
 include_dirs = include_directories('include')

--- a/homi/src/homid.c
+++ b/homi/src/homid.c
@@ -8,13 +8,13 @@
 #include <syslog.h>
 #include <unistd.h>
 
-#include <homi_log.h>
-#include <homi_opts.h>
+#include <homid_log.h>
+#include <homid_opts.h>
 
 
 volatile sig_atomic_t stop = 0;
 
-struct homi_cli_args {
+struct homid_cli_args {
 	char *config_file;
 };
 
@@ -23,17 +23,17 @@ void handle_signal(int sig __attribute__((unused))) {
 }
 
 static int
-parse_args(int argc, char *argv[], struct homi_cli_args *args)
+parse_args(int argc, char *argv[], struct homid_cli_args *args)
 {
 	for (int i = 1; i < argc; i++) {
 		if (strcmp(argv[i], "--config") == 0) {
 			if (i+1 >= argc) {
-				homi_log(LOG_CRIT, "Error: Config argument must define a path to a configuration file");
+				homid_log(LOG_CRIT, "Error: Config argument must define a path to a configuration file");
 				return -EINVAL;
 			}
 			args->config_file = argv[++i];
 		} else {
-			homi_log(LOG_CRIT, "Unexpected argument: %s", argv[i]);
+			homid_log(LOG_CRIT, "Unexpected argument: %s", argv[i]);
 			return -EINVAL;
 		}
 	}
@@ -42,13 +42,13 @@ parse_args(int argc, char *argv[], struct homi_cli_args *args)
 }
 
 static int
-initialize(struct homi_opts *opts)
+initialize(struct homid_opts *opts)
 {
-	homi_log_set_level(opts->log_level);
+	homid_log_set_level(opts->log_level);
 
 	// For now, we just log the devices given in the configuration file.
 	for (int i = 0; i < opts->ndevs; i++) {
-		homi_log(LOG_NOTICE, "Device: %s", opts->dev_uris[i]);
+		homid_log(LOG_NOTICE, "Device: %s", opts->dev_uris[i]);
 	}
 
 	return 0;
@@ -56,31 +56,31 @@ initialize(struct homi_opts *opts)
 
 int main(int argc, char **argv)
 {
-	struct homi_cli_args args = {0};
-	struct homi_opts opts = {0};
+	struct homid_cli_args args = {0};
+	struct homid_opts opts = {0};
 	int err;
 
 	openlog("homi", LOG_PID, LOG_DAEMON);
 
 	err = parse_args(argc, argv, &args);
 	if (err) {
-		homi_log(LOG_CRIT, "Error while parsing the arguments");
+		homid_log(LOG_CRIT, "Error while parsing the arguments");
 		exit(EXIT_FAILURE);
 	}
 
-	err = homi_opts_from_toml(args.config_file, &opts);
+	err = homid_opts_from_toml(args.config_file, &opts);
 	if (err) {
-		homi_log(LOG_CRIT, "Error while parsing the configuration file");
+		homid_log(LOG_CRIT, "Error while parsing the configuration file");
 		goto exit;
 	}
 
 	err = initialize(&opts);
 	if (err) {
-		homi_log(LOG_CRIT, "Could not initialize the HOMI deamon");
+		homid_log(LOG_CRIT, "Could not initialize the HOMI deamon");
 		goto exit;
 	}
 
-	homi_log(LOG_NOTICE, "Daemon initialized");
+	homid_log(LOG_NOTICE, "Daemon initialized");
 
 	signal(SIGTERM, handle_signal);
 	signal(SIGINT, handle_signal);
@@ -88,11 +88,11 @@ int main(int argc, char **argv)
 	while (!stop)
 	{
 		//TODO: Insert daemon code here.
-		homi_log(LOG_INFO, "We are doing something");
+		homid_log(LOG_INFO, "We are doing something");
 		sleep(10);
 	}
 
-	homi_log(LOG_NOTICE, "Daemon terminated");
+	homid_log(LOG_NOTICE, "Daemon terminated");
 
 exit:
 	closelog();

--- a/homi/src/homid_log.c
+++ b/homi/src/homid_log.c
@@ -2,10 +2,10 @@
 #include <stdio.h>
 #include <syslog.h>
 
-static int g_homi_log_level = LOG_NOTICE;
+static int g_homid_log_level = LOG_NOTICE;
 
 void
-homi_log_set_level(int level)
+homid_log_set_level(int level)
 {
 	switch (level)
 	{
@@ -17,24 +17,24 @@ homi_log_set_level(int level)
 	case LOG_WARNING:
 	case LOG_ERR:
 	case LOG_CRIT:
-		g_homi_log_level = level;
+		g_homid_log_level = level;
 		break;
 
 	default:
 		syslog(LOG_WARNING, "WARN: Unknown log level, defaulting to LOG_NOTICE");
-		g_homi_log_level = LOG_NOTICE;
+		g_homid_log_level = LOG_NOTICE;
 		break;
 	}
 }
 
 void
-homi_log(int level, const char *fmt, ...)
+homid_log(int level, const char *fmt, ...)
 {
 	va_list args;
 	const char *prefix;
 	char prefixed_fmt[256];
 
-	if (level > g_homi_log_level) {
+	if (level > g_homid_log_level) {
 		return;
 	}
 

--- a/homi/src/homid_opts.c
+++ b/homi/src/homid_opts.c
@@ -4,11 +4,11 @@
 #include <syslog.h>
 #include <tomlc17.h>
 
-#include <homi_log.h>
-#include <homi_opts.h>
+#include <homid_log.h>
+#include <homid_opts.h>
 
 static int
-get_default_opts(struct homi_opts *opts)
+get_default_opts(struct homid_opts *opts)
 {
 	opts->log_level = LOG_NOTICE;
 
@@ -16,7 +16,7 @@ get_default_opts(struct homi_opts *opts)
 }
 
 int
-homi_opts_from_toml(char *config_file, struct homi_opts *opts)
+homid_opts_from_toml(char *config_file, struct homid_opts *opts)
 {
 	toml_result_t result;
 	toml_datum_t log_level, devices;
@@ -25,10 +25,10 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 	result = toml_parse_file_ex(config_file);
 
 	if (!result.ok) {
-		homi_log(LOG_INFO, "Configuration file did not exit. Returning to defaults");
+		homid_log(LOG_INFO, "Configuration file did not exit. Returning to defaults");
 		err = get_default_opts(opts);
 		if (err) {
-			homi_log(LOG_CRIT, "Error while getting default options");
+			homid_log(LOG_CRIT, "Error while getting default options");
 		}
 		goto exit;
 	}
@@ -36,7 +36,7 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 	log_level = toml_seek(result.toptab, "log_level");
 
 	if (log_level.type != TOML_INT64) {
-		homi_log(LOG_WARNING, "Missing or invalid 'log_level' property in config, defaulting to LOG_NOTICE");
+		homid_log(LOG_WARNING, "Missing or invalid 'log_level' property in config, defaulting to LOG_NOTICE");
 	}
 
 	switch (log_level.u.int64)
@@ -57,7 +57,7 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 		opts->log_level = LOG_DEBUG;
 		break;
 	default:
-		homi_log(LOG_WARNING, "Missing or invalid 'log_level' property in config, defaulting to LOG_NOTICE");
+		homid_log(LOG_WARNING, "Missing or invalid 'log_level' property in config, defaulting to LOG_NOTICE");
 		opts->log_level = LOG_NOTICE;
 		break;
 	}
@@ -65,7 +65,7 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 	devices = toml_seek(result.toptab, "devices");
 
 	if (devices.type != TOML_ARRAY) {
-		homi_log(LOG_ERR, "Missing or invalid 'devices' property in config");
+		homid_log(LOG_ERR, "Missing or invalid 'devices' property in config");
 		err = -EINVAL;
 		goto exit;
 	}
@@ -74,7 +74,7 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 	opts->dev_uris = malloc(devices.u.arr.size * sizeof(*opts->dev_uris));
 	if (!opts->dev_uris) {
 		err = -errno;
-		homi_log(LOG_ERR, "Faied: malloc(); errno(%d)", errno);
+		homid_log(LOG_ERR, "Faied: malloc(); errno(%d)", errno);
 		goto exit;
 	}
 
@@ -82,7 +82,7 @@ homi_opts_from_toml(char *config_file, struct homi_opts *opts)
 		toml_datum_t elem = devices.u.arr.elem[i];
 
 		if (elem.type != TOML_STRING) {
-			homi_log(LOG_ERR, "Invalid device URI: not a string");
+			homid_log(LOG_ERR, "Invalid device URI: not a string");
 			err = -EINVAL;
 			goto exit;
 		}


### PR DESCRIPTION
This is as preparation for separating the homi daemon namespace from the homi client namespace. As the homi client will be included in other projects, the "homi" namespace will be used for that.