### PR TITLE
Basic interface for the HOMI IPC

### DIFF
--- a/homi/Makefile
+++ b/homi/Makefile
@@ -25,6 +25,7 @@ endef
 .PHONY: install
 install:
 	meson install -C builddir
+	ldconfig
 	systemctl daemon-reload
 
 define start-help

--- a/homi/config/homi.conf.in
+++ b/homi/config/homi.conf.in
@@ -6,3 +6,6 @@ log_level = 2
 # Devices is a list of dev URIs as strings, e.g.
 # devices = [ "/dev/nvme0n1", "/dev/nvme1n1" ]
 devices = [ ]
+
+# IPC socket
+ipc_socket = "/run/homi/homi.sock"

--- a/homi/homi.service.in
+++ b/homi/homi.service.in
@@ -3,6 +3,7 @@ Description=Host Orchestrated Multipath I/O
 
 [Service]
 Type=simple
+RuntimeDirectory=homi
 StandardOutput=journal
 StandardError=journal
 ExecStart=@bindir@/homid --config @config@

--- a/homi/include/homi_proto.h
+++ b/homi/include/homi_proto.h
@@ -1,0 +1,52 @@
+#ifndef HOMI_PROTO_H
+#define HOMI_PROTO_H
+
+#include <stdint.h>
+
+#define HOMI_MAX_CONNECTS   8
+
+enum homi_msg_type {
+	/* TODO: add message types as daemon functionality is extended */
+	HOMI_MSG_TYPE_HELLOWORLD = 0, ///< Test type, as an example of what is needed
+};
+
+struct homi_req_helloworld {
+	int32_t value;
+};
+
+struct homi_msg_header {
+	enum homi_msg_type type;
+	size_t payload_len;
+};
+
+/**
+ * Read a message from a socket.
+ *
+ * Reads a homi_msg_header followed by its payload from sock_fd. The payload
+ * is heap-allocated and returned via *buf; the caller is responsible for
+ * freeing it. *buf is set to NULL if payload_len is zero.
+ *
+ * @param sock_fd  File descriptor of the connected socket.
+ * @param hdr      Output: populated with the received message header.
+ * @param buf      Output: allocated buffer containing the payload, or NULL.
+ * @return         0 on success, negative errno on failure.
+ */
+int
+homi_proto_socket_read(int sock_fd, struct homi_msg_header *hdr, char **buf);
+
+/**
+ * Write a message to a socket.
+ *
+ * Sends hdr followed by buf as a single framed message. Sets hdr->payload_len
+ * to buf_len before writing.
+ *
+ * @param sock_fd   File descriptor of the connected socket.
+ * @param hdr       Message header; payload_len will be overwritten with buf_len.
+ * @param buf       Payload to send.
+ * @param buf_len   Length of the payload in bytes.
+ * @return          0 on success, negative errno on failure.
+ */
+int
+homi_proto_socket_write(int sock_fd, struct homi_msg_header *hdr, void *buf, size_t buf_len);
+
+#endif /* HOMI_PROTO_H */

--- a/homi/include/homic.h
+++ b/homi/include/homic.h
@@ -1,0 +1,38 @@
+#ifndef HOMIC_H
+#define HOMIC_H
+
+/**
+ * Connect to the homid daemon.
+ *
+ * Opens a Unix domain socket connection to the daemon. Must be called before
+ * any other homic functions. The connection is held globally; call
+ * homic_disconnect() to release it.
+ *
+ * @return  0 on success, negative errno on failure.
+ */
+int
+homic_connect(char *socket_path);
+
+/**
+ * Disconnect from the homid daemon.
+ *
+ * Closes the socket and releases the global connection. Safe to call if not
+ * connected.
+ */
+void
+homic_disconnect();
+
+/**
+ * Send a helloworld request to the daemon.
+ *
+ * Sends value to the daemon and receives the response string in *out.
+ * Requires an active connection established with homic_connect().
+ *
+ * @param value  Integer to send (ignored by the daemon).
+ * @param out    Output: heap-allocated response string. Caller must free.
+ * @return       0 on success, negative errno on failure.
+ */
+int
+homic_helloworld(int value, char **out);
+
+#endif /* HOMIC_H */

--- a/homi/include/homid.h
+++ b/homi/include/homid.h
@@ -1,1 +1,3 @@
-struct homid {};
+struct homid {
+  struct homid_ipc_connection *conn;
+};

--- a/homi/include/homid.h
+++ b/homi/include/homid.h
@@ -1,0 +1,1 @@
+struct homid {};

--- a/homi/include/homid_ipc.h
+++ b/homi/include/homid_ipc.h
@@ -1,0 +1,38 @@
+struct homid_ipc_connection {
+  int fd;
+};
+
+/**
+ * Open the IPC listener socket.
+ *
+ * Creates and binds a Unix domain socket, then starts listening for incoming
+ * client connections. The resulting connection object is returned via *conn
+ * and must be released with homid_ipc_close().
+ *
+ * @param socket_path  Path to the socket
+ * @param conn         Output: allocated connection object on success.
+ * @return             0 on success, negative errno on failure.
+ */
+int
+homid_ipc_open(char *socket_path, struct homid_ipc_connection **conn);
+
+/**
+ * Close the IPC listener socket and free the connection.
+ *
+ * @param conn  Connection to close. Safe to call with NULL.
+ */
+void
+homid_ipc_close(struct homid_ipc_connection *conn);
+
+/**
+ * Accept an incoming client connection and dispatch a worker thread.
+ *
+ * Blocks until a client connects, then spawns a pthread to handle the
+ * request. Returns immediately after the thread is created, ready to
+ * be called again for the next connection.
+ *
+ * @param conn  Active listener connection opened with homid_ipc_open().
+ * @return      0 on success, negative errno on failure.
+ */
+int
+homid_ipc_accept(struct homid_ipc_connection *conn);

--- a/homi/include/homid_log.h
+++ b/homi/include/homid_log.h
@@ -1,3 +1,5 @@
+#include <syslog.h>
+
 void
 homid_log_set_level(int level);
 

--- a/homi/include/homid_opts.h
+++ b/homi/include/homid_opts.h
@@ -4,6 +4,7 @@ struct homid_opts {
 	int log_level;
 	int ndevs;
 	char (*dev_uris)[HOMID_DEVURI_MAXLEN];
+	char *ipc_socket;
 };
 
 /**

--- a/homi/meson.build
+++ b/homi/meson.build
@@ -35,6 +35,14 @@ executable('homid',
   install_dir: bindir,
 )
 
+library('homic',
+  sources: ['src/homic.c', 'src/homi_proto.c'],
+  include_directories: include_dirs,
+  install: true,
+)
+
+install_headers('include/homic.h')
+
 config_dir = join_paths('/etc', 'homi')
 config_name = 'homi.conf'
 

--- a/homi/meson.build
+++ b/homi/meson.build
@@ -17,8 +17,10 @@ homi_dependencies = [toml_dep]
 
 sources = files(
   'src/homid.c',
+  'src/homid_ipc.c',
   'src/homid_log.c',
   'src/homid_opts.c',
+  'src/homi_proto.c',
 )
 
 include_dirs = include_directories('include')

--- a/homi/src/homi_proto.c
+++ b/homi/src/homi_proto.c
@@ -1,0 +1,92 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <homi_proto.h>
+
+static int
+_read_from_buffer(int sock_fd, void *buf, size_t len)
+{
+	size_t done = 0;
+	ssize_t n;
+
+	while (done < len) {
+		n = read(sock_fd, (char *)buf + done, len - done);
+		if (n < 0) {
+			return -errno;
+		}
+		if (n == 0) {
+			return -EIO;
+		}
+		done += n;
+	}
+
+	return 0;
+}
+
+static int
+_write_to_buffer(int sock_fd, void *buf, size_t len)
+{
+	size_t done = 0;
+	ssize_t n;
+
+	while (done < len) {
+		n = write(sock_fd, (const char *)buf + done, len - done);
+		if (n < 0) {
+			return -errno;
+		}
+		done += n;
+	}
+
+	return 0;
+}
+
+int
+homi_proto_socket_read(int sock_fd, struct homi_msg_header *hdr, char **buf)
+{
+	char *payload = NULL;
+	int err;
+
+	err = _read_from_buffer(sock_fd, hdr, sizeof(*hdr));
+	if (err) {
+		return err;
+	}
+
+	if (hdr->payload_len > 0) {
+		payload = malloc(hdr->payload_len);
+		if (!payload) {
+			err = -errno;
+			return err;
+		}
+
+		err = _read_from_buffer(sock_fd, payload, hdr->payload_len);
+		if (err) {
+			free(payload);
+			return err;
+		}
+	}
+
+	*buf = payload;
+
+	return 0;
+}
+
+int
+homi_proto_socket_write(int sock_fd, struct homi_msg_header *hdr, void *buf, size_t buf_len)
+{
+	int err;
+
+	hdr->payload_len = (uint32_t)buf_len;
+
+	err = _write_to_buffer(sock_fd, hdr, sizeof(*hdr));
+	if (err) {
+		return err;
+	}
+
+	err = _write_to_buffer(sock_fd, buf, buf_len);
+	if (err) {
+		return err;
+	}
+
+	return 0;
+}

--- a/homi/src/homic.c
+++ b/homi/src/homic.c
@@ -1,0 +1,109 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <homic.h>
+#include <homi_proto.h>
+
+struct homic_client {
+	int fd;
+};
+
+static struct homic_client *g_homic_client = NULL;
+
+int
+homic_connect(char *socket_path)
+{
+	struct homic_client *cand;
+	struct sockaddr_un saddr;
+	int fd, err;
+
+	cand = calloc(1, sizeof(*cand));
+	if (!cand) {
+		err = -errno;
+		fprintf(stderr, "Failed: calloc(); err(%d)\n", err);
+		return err;
+	}
+
+	fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	if (fd < 0) {
+		err = -errno;
+		fprintf(stderr, "Failed: socket(); err(%d)\n", err);
+		goto failed;
+	}
+
+	saddr.sun_family = AF_LOCAL;
+	strncpy(saddr.sun_path, socket_path, sizeof(saddr.sun_path));
+	saddr.sun_path[sizeof(saddr.sun_path) - 1] = '\0';
+
+	err = connect(fd, (struct sockaddr *)&saddr, sizeof(saddr));
+	if (err) {
+		err = -errno;
+		fprintf(stderr, "Failed: connect(); err(%d)\n", err);
+		close(fd);
+		goto failed;
+	}
+
+	cand->fd = fd;
+	g_homic_client = cand;
+
+	return 0;
+
+failed:
+	free(cand);
+	return err;
+}
+
+void
+homic_disconnect()
+{
+	if (!g_homic_client) {
+		return;
+	}
+
+	if (g_homic_client->fd >= 0) {
+		close(g_homic_client->fd);
+	}
+
+	free(g_homic_client);
+	g_homic_client = NULL;
+}
+
+int
+homic_helloworld(int32_t value, char **out)
+{
+	struct homi_msg_header hdr = {0};
+	struct homi_req_helloworld req = {0};
+	enum homi_msg_type msg_type = HOMI_MSG_TYPE_HELLOWORLD;
+	char *response;
+	int err;
+
+	if (!g_homic_client) {
+		err = -ENOTCONN;
+		fprintf(stderr, "Failed: No connection, please call homic_client_connect(); err(%d)\n", err);
+		return err;
+	}
+
+	req.value = value;
+	hdr.type = msg_type;
+	hdr.payload_len = sizeof(req);
+
+	err = homi_proto_socket_write(g_homic_client->fd, &hdr, &req, sizeof(req));
+	if (err) {
+		fprintf(stderr, "Failed: homi_proto_socket_write(hdr); err(%d)\n", err);
+		return err;
+	}
+
+	err = homi_proto_socket_read(g_homic_client->fd, &hdr, &response);
+	if (err) {
+		fprintf(stderr, "Failed: homi_proto_socket_read(hdr); err(%d)\n", err);
+		return err;
+	}
+
+	*out = response;
+	return 0;
+}

--- a/homi/src/homid.c
+++ b/homi/src/homid.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <homid.h>
+#include <homid_ipc.h>
 #include <homid_log.h>
 #include <homid_opts.h>
 
@@ -60,6 +61,12 @@ homid_initialize(struct homid_opts *opts, struct homid **homid)
 		return -errno;
 	}
 
+	err = homid_ipc_open(opts->ipc_socket, &cand->conn);
+	if (err) {
+		homid_log(LOG_ERR, "Failed: homid_ipc_open()");
+		goto failed;
+	}
+
 	// For now, we just log the devices given in the configuration file.
 	for (int i = 0; i < opts->ndevs; i++) {
 		homid_log(LOG_NOTICE, "Device: %s", opts->dev_uris[i]);
@@ -80,6 +87,8 @@ homid_close(struct homid *homid) {
 		homid_log(LOG_INFO, "No homid given; skipping homid_close()");
 		return 0;
 	}
+
+	homid_ipc_close(homid->conn);
 
 	return 0;
 }
@@ -113,14 +122,17 @@ int main(int argc, char **argv)
 
 	homid_log(LOG_NOTICE, "Daemon initialized");
 
-	signal(SIGTERM, handle_signal);
-	signal(SIGINT, handle_signal);
+	struct sigaction sa = {
+		.sa_handler = handle_signal,
+		.sa_flags   = 0,
+	};
+	sigemptyset(&sa.sa_mask);
+	sigaction(SIGTERM, &sa, NULL);
+	sigaction(SIGINT, &sa, NULL);
 
 	while (!stop)
 	{
-		//TODO: Insert daemon code here.
-		homid_log(LOG_INFO, "We are doing something");
-		sleep(10);
+		homid_ipc_accept(homid->conn);
 	}
 
 	homid_log(LOG_NOTICE, "Daemon terminated");

--- a/homi/src/homid.c
+++ b/homi/src/homid.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <homid.h>
 #include <homid_log.h>
 #include <homid_opts.h>
 
@@ -16,6 +17,9 @@ volatile sig_atomic_t stop = 0;
 struct homid_cli_args {
 	char *config_file;
 };
+
+static int
+homid_close(struct homid *homid);
 
 static void
 handle_signal(int sig __attribute__((unused)))
@@ -43,13 +47,38 @@ parse_args(int argc, char *argv[], struct homid_cli_args *args)
 }
 
 static int
-initialize(struct homid_opts *opts)
+homid_initialize(struct homid_opts *opts, struct homid **homid)
 {
+	struct homid *cand;
+	int err;
+
 	homid_log_set_level(opts->log_level);
+
+	cand = calloc(1, sizeof(*cand));
+	if (!cand) {
+		homid_log(LOG_CRIT, "FAILED: calloc(); errno(%d)", errno);
+		return -errno;
+	}
 
 	// For now, we just log the devices given in the configuration file.
 	for (int i = 0; i < opts->ndevs; i++) {
 		homid_log(LOG_NOTICE, "Device: %s", opts->dev_uris[i]);
+	}
+
+	*homid = cand;
+
+	return 0;
+
+failed:
+	homid_close(cand);
+	return err;
+}
+
+static int
+homid_close(struct homid *homid) {
+	if (!homid) {
+		homid_log(LOG_INFO, "No homid given; skipping homid_close()");
+		return 0;
 	}
 
 	return 0;
@@ -59,6 +88,7 @@ int main(int argc, char **argv)
 {
 	struct homid_cli_args args = {0};
 	struct homid_opts opts = {0};
+	struct homid *homid = NULL;
 	int err;
 
 	openlog("homi", LOG_PID, LOG_DAEMON);
@@ -75,7 +105,7 @@ int main(int argc, char **argv)
 		goto exit;
 	}
 
-	err = initialize(&opts);
+	err = homid_initialize(&opts, &homid);
 	if (err) {
 		homid_log(LOG_CRIT, "Could not initialize the HOMI deamon");
 		goto exit;
@@ -96,6 +126,8 @@ int main(int argc, char **argv)
 	homid_log(LOG_NOTICE, "Daemon terminated");
 
 exit:
+	homid_close(homid);
+	free(homid);
 	closelog();
 	free(opts.dev_uris);
 

--- a/homi/src/homid.c
+++ b/homi/src/homid.c
@@ -17,7 +17,9 @@ struct homid_cli_args {
 	char *config_file;
 };
 
-void handle_signal(int sig __attribute__((unused))) {
+static void
+handle_signal(int sig __attribute__((unused)))
+{
 	stop = 1;
 }
 

--- a/homi/src/homid.c
+++ b/homi/src/homid.c
@@ -5,7 +5,6 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 #include <unistd.h>
 
 #include <homid_log.h>

--- a/homi/src/homid_ipc.c
+++ b/homi/src/homid_ipc.c
@@ -1,0 +1,166 @@
+#include <errno.h>
+#include <stdint.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <homid_ipc.h>
+#include <homid_log.h>
+#include <homi_proto.h>
+
+static int
+_open_socket(char *socket_path)
+{
+	struct sockaddr_un saddr;
+	int fd, err = 0;
+
+	fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+	if (fd < 0) {
+		homid_log(LOG_ERR, "Failed: socket(); err(%d)", errno);
+		return -errno;
+	}
+
+	saddr.sun_family = AF_LOCAL;
+	strncpy(saddr.sun_path, socket_path, sizeof(saddr.sun_path));
+	saddr.sun_path[sizeof(saddr.sun_path) - 1] = '\0';
+
+	err = bind(fd, (struct sockaddr *)&saddr, sizeof(saddr));
+	if (err) {
+		homid_log(LOG_ERR, "Failed: bind(); err(%d)", errno);
+		close(fd);
+		return -errno;
+	}
+
+	return fd;
+}
+
+int
+homid_ipc_open(char *socket_path, struct homid_ipc_connection **conn)
+{
+	struct homid_ipc_connection *cand;
+	int fd, err = 0;
+
+	cand = calloc(1, sizeof(*cand));
+	if (!cand) {
+		err = -errno;
+		homid_log(LOG_CRIT, "Failed: calloc(); errno(%d)", err);
+		return err;
+	}
+
+	fd = _open_socket(socket_path);
+	if (fd < 0) {
+		err = fd;
+		homid_log(LOG_ERR, "Failed: _open_socket(); err(%d)", err);
+		goto failed;
+	}
+	cand->fd = fd;
+
+	err = listen(fd, HOMI_MAX_CONNECTS);
+	if (err) {
+		err = -errno;
+		homid_log(LOG_ERR, "Failed: listen(); err(%d)", err);
+		goto failed;
+	}
+
+	homid_log(LOG_INFO, "Listening for client connections ...");
+
+	*conn = cand;
+
+	return 0;
+
+failed:
+	homid_ipc_close(cand);
+
+	return err;
+}
+
+void
+homid_ipc_close(struct homid_ipc_connection *conn)
+{
+	if (!conn) {
+		homid_log(LOG_INFO, "No homid_ipc_connection given; skipping homid_ipc_close()");
+		return;
+	}
+
+	if (conn->fd >= 0) {
+		close(conn->fd);
+	}
+}
+
+static void *
+worker(void *arg)
+{
+	int sock_fd = (int)(intptr_t)arg;
+	struct homi_msg_header hdr;
+	char *payload;
+	int err;
+
+	err = homi_proto_socket_read(sock_fd, &hdr, &payload);
+	if (err) {
+		homid_log(LOG_ERR, "Failed: homi_proto_socket_read(hdr); err(%d)", err);
+		goto exit;
+	}
+
+	switch ((enum homi_msg_type)hdr.type) {
+	case HOMI_MSG_TYPE_HELLOWORLD: {
+		struct homi_req_helloworld *request = (struct homi_req_helloworld *)payload;
+		char *response;
+
+		if (!request) {
+			homid_log(LOG_ERR, "Error: Payload required for HELLOWORLD request");
+			goto exit;
+		}
+
+		homid_log(LOG_INFO, "Helloworld: received %d", request->value);
+
+		response = "hello world!";
+		hdr.payload_len = strlen(response) + 1;
+
+		err = homi_proto_socket_write(sock_fd, &hdr, response, strlen(response) + 1);
+		if (err) {
+			homid_log(LOG_ERR, "Failed: homi_proto_socket_write(); err(%d)", err);
+			goto exit;
+		}
+
+		break;
+	}
+	default:
+		homid_log(LOG_WARNING, "Unknown message type: %u", hdr.type);
+		break;
+	}
+
+exit:
+	free(payload);
+	close(sock_fd);
+	return NULL;
+}
+
+int
+homid_ipc_accept(struct homid_ipc_connection *conn)
+{
+	struct sockaddr addr;
+	pthread_t thr_id;
+	uint32_t len;
+	int client_fd, err;
+
+	len = sizeof(addr);
+
+	homid_log(LOG_DEBUG, "Waiting for incoming connections...\n");
+	client_fd = accept(conn->fd, &addr, &len);
+
+	if (client_fd < 0) {
+		homid_log(LOG_WARNING, "Failed: accept(); continuing");
+		return 0;
+	}
+
+	err = pthread_create(&thr_id, NULL, worker, (void *)(intptr_t)client_fd);
+	if (err) {
+			homid_log(LOG_ERR, "Failed: pthread_create(); err(%d)", err);
+			return err;
+	}
+
+	return 0;
+}

--- a/homi/src/homid_opts.c
+++ b/homi/src/homid_opts.c
@@ -18,7 +18,7 @@ int
 homid_opts_from_toml(char *config_file, struct homid_opts *opts)
 {
 	toml_result_t result;
-	toml_datum_t log_level, devices;
+	toml_datum_t log_level, devices, ipc_socket;
 	int err = 0;
 
 	result = toml_parse_file_ex(config_file);
@@ -88,6 +88,22 @@ homid_opts_from_toml(char *config_file, struct homid_opts *opts)
 
 		strcpy(opts->dev_uris[i], elem.u.s);
 	}
+
+	ipc_socket = toml_seek(result.toptab, "ipc_socket");
+
+	if (ipc_socket.type != TOML_STRING) {
+		homid_log(LOG_ERR, "Missing or invalid 'ipc_socket' property in config");
+		err = -EINVAL;
+		goto exit;
+	}
+
+	opts->ipc_socket = malloc(strlen(ipc_socket.u.s) + 1);
+	if (!opts->ipc_socket) {
+		err = -errno;
+		homid_log(LOG_ERR, "Failed: malloc(); errno(%d)", errno);
+		goto exit;
+	}
+	strcpy(opts->ipc_socket, ipc_socket.u.s);
 
 exit:
 	toml_free(result);

--- a/homi/src/homid_opts.c
+++ b/homi/src/homid_opts.c
@@ -1,7 +1,6 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include <syslog.h>
 #include <tomlc17.h>
 
 #include <homid_log.h>


### PR DESCRIPTION
These commits implement the skeleton for doing IPC with HOMI. A shared protocol is defined by `homi_proto`. On the daemon side, it creates a socket and listens to that. A client library is defined by `homic`.

Because HOMI still has no real functionality, I've added just a single example endpoint "helloworld". It acts as an example of how to define input and output for communication, and how to handle it on both ends. As we add functionality to HOMI, we might want to remove this.

I've written a simple test C program using the helloworld endpoint:
[homi-ipc-test.c](https://github.com/user-attachments/files/25930320/homi-ipc-test.c)
