### PR TITLE
Add xnvmeperf to benchmarking workflow

### DIFF
--- a/docs/src/experiments.md
+++ b/docs/src/experiments.md
@@ -190,7 +190,7 @@ it can be run with command
 #### Running the Experiment
 
 When the system has been setup, the cijoe workflow must be configured with the
-right benchmarking parameters. In the file ``tasks/bench_bdevperf_cpu.yaml``, the
+right benchmarking parameters. In the file ``tasks/bench_io.yaml``, the
 step "run" has multiple keys under "with" which represent the independent
 variables of the experiment. The key ``results_dir`` is optional, but allows
 continuation of previously run benchmarks. Note that the ``numcpus_range`` and
@@ -202,7 +202,7 @@ times each benchmark is run; if not defined, the default is 5 repetitions.
 When the "run" step has been parameterized, the workflow can be run with command
 
     cijoe --monitor \
-      tasks/bench_bdevperf_cpu.yaml \
+      tasks/bench_io.yaml \
       -c configs/aisio.toml \
       -c configs/devices_16.toml
 
@@ -212,7 +212,7 @@ repeatedly if running the benchmarks multiple times in a row. These steps can be
 skipped by specifying which steps to run in the command
 
     cijoe \
-      tasks/bench_bdevperf_cpu.yaml \
+      tasks/bench_io.yaml \
       -c configs/aisio.toml \
       -c configs/devices_16.toml
       run combine visualize

--- a/scripts/bench_combine.py
+++ b/scripts/bench_combine.py
@@ -38,7 +38,7 @@ def main(args, cijoe: Cijoe):
         REGEX = r".*-thrsib(?P<ht>[01])-freq_.*-stress(?P<st>[01])-SMT(?P<sm>[01])-turbo(?P<tu>[01])-\d"
         m = match(REGEX, path.stem)
         if not m:
-            log.error(f"Failed parsing filname({path.stem})")
+            log.error(f"Failed parsing filename({path.stem})")
             return 1
 
         ht, st, sm, tu = map(int, m.groups())
@@ -60,6 +60,10 @@ def main(args, cijoe: Cijoe):
         if err:
             log.error("Failed: merge_dicts()")
             return err
+
+        if "tool" not in result:
+            result["tool"] = "bdevperf"
+            result["backend"] = "spdk"
 
         result["iops"] = avg_stddev(result["iops"])
         result["mibs"] = avg_stddev(result["mibs"])

--- a/scripts/bench_combine.py
+++ b/scripts/bench_combine.py
@@ -1,8 +1,8 @@
 """
-Combine results from running CPU benchmarks
+Combine results from running I/O benchmarks
 ===========================================
 
-Combine the results from running the CPU benchmarks in `bdevperf_runall.py`.
+Combine the results from running the CPU benchmarks in `bench_runall.py`.
 
 Retargetable: True
 ------------------
@@ -24,10 +24,10 @@ def add_args(parser: ArgumentParser):
 
 
 def main(args, cijoe: Cijoe):
-    """Run benchmarks using bdevperf"""
+    """Combine benchmark results into a single JSON"""
 
     artifacts = Path(args.output) / "artifacts"
-    bdev_results = artifacts / "bdevperf-results"
+    bdev_results = artifacts / "bench-results"
 
     if args.results_dir:
         bdev_results = args.results_dir

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -1,6 +1,6 @@
 """
-BdevperfHelper
-==============
+BenchHelper
+===========
 
 Helper class for running benchmarks with SPDK's I/O benchmarking tool, bdevperf.
 
@@ -31,7 +31,7 @@ import json
 import logging as log
 
 
-class BdevperfHelper():
+class BenchHelper():
     def __init__(
             self,
             cijoe: Cijoe,

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -37,7 +37,9 @@ class BenchHelper():
             cijoe: Cijoe,
             configs_path: Path,
             results_path: Path,
-            cfm: CpuFrequencyHelper
+            cfm: CpuFrequencyHelper,
+            backend: str = "spdk",
+            tool: str = "bdevperf",
     ):
         self.initialised = False
 
@@ -46,6 +48,8 @@ class BenchHelper():
         self.configs_path = configs_path
         self.cfm = cfm
         self.stress = False
+        self.backend = backend
+        self.tool = tool
 
         self.use_thrsib = False
         err = self._create_cpumasks(self.use_thrsib)
@@ -56,12 +60,15 @@ class BenchHelper():
         self.remote_config = Path("/tmp/bdevperf-config.json")
         self.devices: list = cijoe.getconf("devices")
 
-        spdk_path = self.cijoe.getconf("spdk.repository.path", None)
-        if not spdk_path:
-            log.error("Failed: Missing SPDK repository path in config")
-            return
+        if tool == "bdevperf":
+            spdk_path = self.cijoe.getconf("spdk.repository.path", None)
+            if not spdk_path:
+                log.error("Failed: Missing SPDK repository path in config")
+                return
 
-        self.bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
+            self.bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
+        else:
+            log.error(f"Failed: Unknown tool({tool})")
 
         self.initialised = True
 
@@ -92,6 +99,8 @@ class BenchHelper():
             f"c{ncpus}-"
             f"o{size}-"
             f"q{depth}-"
+            f"be_{self.backend}-"
+            f"tool_{self.tool}-"
             f"thrsib{1 if self.use_thrsib else 0}-"
             f"freq_{cpu_freq}-"
             f"stress{1 if self.stress else 0}"
@@ -105,9 +114,10 @@ class BenchHelper():
                 result = json.load(file)
                 return 0, result
 
-        config_local_path = self.configs_path / f"d{ndevs}.json"
-        self._create_config(self.devices[0:ndevs], config_local_path)
-        self.cijoe.put(config_local_path, self.remote_config)
+        if self.tool == "bdevperf":
+            config_local_path = self.configs_path / f"d{ndevs}.json"
+            self._create_bdevperf_config(self.devices[0:ndevs], config_local_path)
+            self.cijoe.put(config_local_path, self.remote_config)
 
         mask = self.cpu_masks[ncpus]
         selected_cpus = [v[0] for v in self.cpu_pairs if int(mask, 16) & (1 << v[0])]
@@ -119,35 +129,46 @@ class BenchHelper():
             log.error("Failed: CpuFrequencyHelper.start_logging()")
             return err, None
 
-        bdevperf_cmd = (
-            "/usr/bin/time "
-            f"{self.bin} -c {self.remote_config} "
-            f"-m {mask} "
-            f"-q {depth} "
-            f"-o {size} "
-            f"-t {time} "
-            "-w randread "
-        )
+        command = f"/usr/bin/time {self.bin} "
+
+        if self.tool == "bdevperf":
+            run_parameters = [
+                f"-c {self.remote_config}",
+                f"-m {mask}",
+                f"-q {depth}",
+                f"-o {size}",
+                f"-t {time}",
+                "-w randread"
+            ]
+            command += " ".join(run_parameters)
+        else:
+            log.error(f"Unkown tool: {self.tool}")
+            return -1
 
         if self.stress and (stressed_cpus := [str(x) for x in range(len(self.cpu_pairs)) if x not in selected_cpus]):
-            bdevperf_cmd = "\n".join([
+            command = "\n".join([
                 f"taskset -c {','.join(stressed_cpus)} stress-ng --cpu {len(stressed_cpus)} --timeout {time + 5}s &",
                 "STRESS_PID=$!",
-                bdevperf_cmd,
+                command,
                 "wait $STRESS_PID",
             ])
 
-        err, state = self.cijoe.run(bdevperf_cmd)
+        err, state = self.cijoe.run(command)
         if err:
-            log.error(f"Failed: {self.bin}")
+            log.error(f"Failed: {self.bin} for run with filename({filename})")
             return err, None
 
         output = state.output()
         err, cpu_usage = self._parse_time_output(output)
         if err:
-            log.error("Failed: cpu_usage()")
+            log.error("Failed: BenchHelper._parse_time_output()")
             return err, None
-        bench_result = self._parse_bdevperf_result(output)
+
+        err, bench_result = self._parse_bench_results(output)
+        if err:
+            log.error("Failed: BenchHelper._parse_bench_results()")
+            return err, None
+
 
         err, cpu_freqs = self.cfm.stop_logging_and_parse()
         if err:
@@ -166,6 +187,8 @@ class BenchHelper():
             "fixed_freq": self.cfm.fixed_freq,
             "cpu_governor": self.cfm.governor,
             "thr_sib": self.use_thrsib,
+            "tool": self.tool,
+            "backend": self.backend,
             "iops": bench_result["total"]["iops"],
             "mibs": bench_result["total"]["mibs"],
         }
@@ -224,7 +247,7 @@ class BenchHelper():
 
         return 0
 
-    def _create_config(self, devices: list, path: Path) -> int:
+    def _create_bdevperf_config(self, devices: list, path: Path) -> int:
         """
         Create a configuration json file for running bdevperf, following the format of
         /path/to/spdk/test/bdev/bdevperf/conf.json
@@ -254,17 +277,24 @@ class BenchHelper():
 
         return 0
 
-    def _parse_bdevperf_result(self, table: str) -> dict[str, list]:
+    def _parse_bench_results(self, table: str) -> Tuple[int, dict[str, list]]:
         """
-        Parse the table-formattet stdout output from running bdevperf into an ansible json
+        Parse the table-formattet stdout output from running the benchmark into an ansible json
         object.
 
-        Returns `result`, which is the json object describing the result
+        Returns `(err, result)`, where a non-zero value for `err` describes that the
+        output did not match the expected format.
         """
 
         result = { "devices": [] }
+        table_regex = None
 
-        table_regex = r"\s*(?P<name>\w+)\s+:\s+(?P<runtime>[0-9.]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)\s+(?P<tos>[0-9.]+)\s+(?P<avg_lat>[0-9.]+)\s+(?P<min_lat>[0-9.]+)\s+(?P<max_lat>[0-9.]+)"
+        if self.tool == "bdevperf":
+            table_regex = r"\s*(?P<name>\w+)\s+:\s+(?P<runtime>[0-9.]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)\s+(?P<tos>[0-9.]+)\s+(?P<avg_lat>[0-9.]+)\s+(?P<min_lat>[0-9.]+)\s+(?P<max_lat>[0-9.]+)"
+        else:
+            log.error(f"Unkown tool: {self.tool}")
+            return -1, None
+
         matches = filter(None, [match(table_regex, row) for row in table.split("\n")])
 
         for m in matches:
@@ -274,7 +304,7 @@ class BenchHelper():
             else:
                 result["devices"].append(device_result)
 
-        return result
+        return 0, result
 
     def _parse_time_output(self, output: str) -> Tuple[int, int]:
         """

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -38,8 +38,8 @@ class BenchHelper():
             configs_path: Path,
             results_path: Path,
             cfm: CpuFrequencyHelper,
-            backend: str = "spdk",
             tool: str = "bdevperf",
+            backend: str = "spdk",
     ):
         self.initialised = False
 
@@ -67,6 +67,8 @@ class BenchHelper():
                 return
 
             self.bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
+        elif tool == "xnvmeperf":
+            self.bin = "xnvmeperf run"
         else:
             log.error(f"Failed: Unknown tool({tool})")
 
@@ -139,6 +141,17 @@ class BenchHelper():
                 f"-o {size}",
                 f"-t {time}",
                 "-w randread"
+            ]
+            command += " ".join(run_parameters)
+        elif self.tool == "xnvmeperf":
+            run_parameters = [
+                f"--cpumask {mask}",
+                f"--qdepth {depth}",
+                f"--iosize {size}",
+                f"--runtime {time}",
+                "--iopattern randread",
+                f"--be {self.backend}",
+                " ".join(d["pci_addr"] for d in self.devices[0:ndevs]),
             ]
             command += " ".join(run_parameters)
         else:
@@ -291,6 +304,8 @@ class BenchHelper():
 
         if self.tool == "bdevperf":
             table_regex = r"\s*(?P<name>\w+)\s+:\s+(?P<runtime>[0-9.]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)\s+(?P<tos>[0-9.]+)\s+(?P<avg_lat>[0-9.]+)\s+(?P<min_lat>[0-9.]+)\s+(?P<max_lat>[0-9.]+)"
+        elif self.tool == "xnvmeperf":
+            table_regex = r"\s*(?P<name>\w+):?\s+(?P<cpus>[0-9,]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)"
         else:
             log.error(f"Unkown tool: {self.tool}")
             return -1, None

--- a/scripts/bench_runall.py
+++ b/scripts/bench_runall.py
@@ -38,6 +38,8 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--time", type=int, default=10, help="Time for for bdevperf to run for each test")
     parser.add_argument("--results_dir", type=Path, default=None, help="Path to existing directory in which the results should be saved. Note: Already existing results will not be benchmarked again")
     parser.add_argument("--repetitions", type=int, default=5, help="The amount of times each benchmark will be repeated. The result will be average of the repetitions")
+    parser.add_argument("--tool", choices=["bdevperf", "xnvmeperf"], default="xnvmeperf")
+    parser.add_argument("--backend", type=str, default="upcie")
 
 
 def main(args, cijoe: Cijoe):
@@ -71,7 +73,7 @@ def main(args, cijoe: Cijoe):
         log.error("Failed: transfer_cpu_frequency_logger()")
         return err
 
-    benchmarker = BenchHelper(cijoe, bdev_configs, bdev_results, cfm)
+    benchmarker = BenchHelper(cijoe, bdev_configs, bdev_results, cfm, args.tool, args.backend)
     if not benchmarker.initialised:
         log.error("Failed: could not initialise BenchHelper")
         return 1

--- a/scripts/bench_runall.py
+++ b/scripts/bench_runall.py
@@ -1,6 +1,6 @@
 """
-Run I/O benchmarks using bdevperf
-=================================
+Run I/O benchmarks
+==================
 
 Run many benchmarks using SPDK's I/O benchmarking tool, bdevperf.
 
@@ -19,7 +19,7 @@ import logging as log
 
 from cijoe.core.command import Cijoe
 
-from bdevperf_helper import BdevperfHelper
+from bench_helper import BenchHelper
 from cpu_freq_helper import CpuFrequencyHelper
 
 
@@ -41,11 +41,11 @@ def add_args(parser: ArgumentParser):
 
 
 def main(args, cijoe: Cijoe):
-    """Run benchmarks using bdevperf"""
+    """Run benchmarks"""
 
     out_path = Path(args.output)
     bdev_configs = out_path / cijoe.output_ident / "bdevperf-configs"
-    bdev_results = out_path / "artifacts" / "bdevperf-results"
+    bdev_results = out_path / "artifacts" / "bench-results"
 
     if args.results_dir:
         bdev_results = args.results_dir
@@ -71,9 +71,9 @@ def main(args, cijoe: Cijoe):
         log.error("Failed: transfer_cpu_frequency_logger()")
         return err
 
-    bdevperf = BdevperfHelper(cijoe, bdev_configs, bdev_results, cfm)
-    if not bdevperf.initialised:
-        log.error("Failed: couldn't not initialise the bdevperf")
+    benchmarker = BenchHelper(cijoe, bdev_configs, bdev_results, cfm)
+    if not benchmarker.initialised:
+        log.error("Failed: could not initialise BenchHelper")
         return 1
 
     test_devs = args.numdevs_specific
@@ -88,7 +88,7 @@ def main(args, cijoe: Cijoe):
         # hyper threading is enabled, the amount of logical CPUs is doubled, and the IDs
         # shift. Now, the same range 4-8 need to be shifted to (7-16), as 1-6 describe the
         # hyper threads on the first 3 cores which are not in the 4-8 range.
-        test_cpus = create_range(args.numcpus_range, bdevperf.cpu_pairs)
+        test_cpus = create_range(args.numcpus_range, benchmarker.cpu_pairs)
 
     tests = []
 
@@ -114,12 +114,12 @@ def main(args, cijoe: Cijoe):
             log.error(f"Failed: cfm.toggle_turbo({tu})")
             return err
 
-        err = bdevperf.use_thread_siblings(ht)
+        err = benchmarker.use_thread_siblings(ht)
         if err:
-            log.error(f"Failed: bdevperf.use_thread_siblings({ht})")
+            log.error(f"Failed: benchmarker.use_thread_siblings({ht})")
             return err
 
-        bdevperf.stress = st
+        benchmarker.stress = st
 
         suffix = f"-SMT{sm}-turbo{tu}"
 
@@ -129,9 +129,9 @@ def main(args, cijoe: Cijoe):
         now = time()
 
         for i in range(args.repetitions):
-            err, result = bdevperf.run_benchmark(qd, iosz, devs, cpus, args.time, freq, f"{suffix}-{i}")
+            err, result = benchmarker.run_benchmark(qd, iosz, devs, cpus, args.time, freq, f"{suffix}-{i}")
             if err:
-                log.error("Failed: run_bdevperf()")
+                log.error("Failed: run_benchmark()")
                 return err
 
             if not result:

--- a/scripts/bench_visualize.py
+++ b/scripts/bench_visualize.py
@@ -1,8 +1,8 @@
 """
-Visualize the bdevperf benchmarks
-=================================
+Visualize the benchmarks
+========================
 
-Parse the results from running scripts/bdevperf_runall.py from JSON format, and
+Parse the results from running scripts/bench_runall.py from JSON format, and
 create the HTML file, which visualizes the data.
 
 Retargetable: False

--- a/scripts/cpu_freq_helper.py
+++ b/scripts/cpu_freq_helper.py
@@ -68,6 +68,9 @@ class CpuFrequencyHelper():
             log.error("Failed: cpupower")
             return 1
 
+        self.fixed_freq = freq
+        self.governor = gvnr
+
         return 0
 
     def _clear_fixed_cpu_freq(self, governor: str = "ondemand") -> int:
@@ -82,6 +85,9 @@ class CpuFrequencyHelper():
         if err:
             log.error("Failed: cpupower")
             return 1
+
+        self.fixed_freq = 0
+        self.governor = governor
 
         return 0
 

--- a/tasks/bench_io.yaml
+++ b/tasks/bench_io.yaml
@@ -1,14 +1,10 @@
 doc: |
-  Run the benchmarks using SPDK's bdevperf tool
-  =============================================
+  Run I/O benchmarks
+  ==================
 
   Configuration file
   ------------------
-  See `configs/bench-amd.toml` for an example configuration file.
-
-  You must change the `cijoe.transport.bench` key to have the correct remote hostname,
-  username and path to a ssh key. If you run the cijoe script on same machine as the
-  benchmarks, delete these fields completely.
+  See `configs/devices_16.toml` for an example configuration file.
 
   The configuration file must also define a list of NVMe block devices. To find these,
   run
@@ -51,7 +47,7 @@ steps:
     {{ config.xnvme.driver.prefix }} xnvme-driver
 
 - name: run
-  uses: bdevperf_runall
+  uses: bench_runall
   with:
     depths: [64, 128, 256]
     sizes: [512, 4096]
@@ -65,9 +61,9 @@ steps:
     results_dir: &results-dir "{{ local.env.HOME }}/bench-results"
 
 - name: combine
-  uses: bdevperf_combine
+  uses: bench_combine
   with:
     results_dir: *results-dir
 
 - name: visualize
-  uses: bdevperf_visualize
+  uses: bench_visualize

--- a/tasks/bench_io.yaml
+++ b/tasks/bench_io.yaml
@@ -59,6 +59,8 @@ steps:
     hyperthreads: [0,1]
     stress: [0,1]
     results_dir: &results-dir "{{ local.env.HOME }}/bench-results"
+    tool: xnvmeperf
+    backend: upcie
 
 - name: combine
   uses: bench_combine

--- a/templates/benchmark-visualization.html.jinja2
+++ b/templates/benchmark-visualization.html.jinja2
@@ -163,6 +163,10 @@
   <span id="iosizeRadios"></span>
   <strong>CPU Frequency or Governor:</strong>
   <span id="cpufreqRadios"></span>
+  <strong>Backend:</strong>
+  <span id="backendRadios"></span>
+  <strong>Benchmarking tool:</strong>
+  <span id="toolRadios"></span>
 </div>
 <div class="controls">
   <strong>Value on y-axis:</strong>
@@ -224,6 +228,8 @@ const getXvalues = () => {
     {elemId: "devicesRadios", key: "ndevs", prettyName: "Number of Devices"},
     {elemId: "iosizeRadios", key: "iosize", prettyName: "I/O Size"},
     {elemId: "cpufreqRadios", key: "fixed_freq", prettyName: "CPU Frequency or Governor" },
+    {elemId: "toolRadios", key: "tool", prettyName: "Tool" },
+    {elemId: "backendRadios", key: "backend", prettyName: "Backend" },
   ].map(s => ({...s, set: [...new Set(allData.map(d => d[s.key]))].sort((a,b) => a - b) }));
 }
 
@@ -269,6 +275,8 @@ document.querySelectorAll(`input[type="radio"]`).forEach(radio => {
 function updateRadios() {
   xValues.forEach(({elemId, set, key}, i) => {
     let button = document.querySelector(`.controls .button-row.x button[value="${i}"]`);
+    if (!button) return;
+
     const container = document.getElementById(elemId);
 
     if (i == CUR_X_AXIS) {


### PR DESCRIPTION
This PR removes "bdevperf" from the namings of benchmarking scripts and workflows, and expands the workflow to accept different benchmarking tools, for now only bdevperf and xnvmeperf. This allows us to use xnvmeperf to produce benchmark results and prepares us for running the benchmarks with P2P payloads.