### PR TITLE
Add setup of amdstack (amdgpu and ROCm)

### DIFF
--- a/configs/amdstack.toml
+++ b/configs/amdstack.toml
@@ -1,0 +1,2 @@
+[amd.amdgpu_install]
+url = "https://repo.radeon.com/amdgpu-install/7.2/ubuntu/noble/amdgpu-install_7.2.70200-1_all.deb"

--- a/configs/transport.toml
+++ b/configs/transport.toml
@@ -2,7 +2,7 @@
 fail_fast=true
 
 [cijoe.transport.ssh]
-hostname = "aisio-nvstack-01"
+hostname = "aisio"
 password = "odus.321"
 username = "root"
 timeout = 1

--- a/tasks/setup_amdstack.yaml
+++ b/tasks/setup_amdstack.yaml
@@ -1,0 +1,99 @@
+doc: |
+  Ubuntu 24.04 Setup of the AMD GPU Software Stack (amdgpu + ROCm)
+  ================================================================
+
+  This workflow provisions a system with the AMD GPU software stack required for
+  NVMe <-> GPU development, testing, and experimentation. It targets the following
+  components and versions:
+
+  * Ubuntu Server 24.04.4
+  * Linux 6.8 GA kernel (HWE must be disabled)
+  * AMDGPU DKMS driver (via amdgpu-install 7.2)
+  * ROCm 7.2 (via amdgpu-install)
+
+  This workflow assumes that the base Ubuntu preparation has already been
+  completed using ``setup_ubuntu.yaml``.
+
+  Running the Workflow
+  --------------------
+  After running ``setup_ubuntu.yaml``, run:
+
+      cijoe --monitor \
+        -c configs/transport.toml \
+        -c configs/amdstack.toml \
+        tasks/setup_amdstack.yaml
+
+  Make sure ``transport.toml`` contains the correct hostname and login
+  credentials for the root user.
+
+  ROCm Environment
+  ----------------
+  ROCm is installed to ``/opt/rocm``. The workflow installs a helper script in
+  ``/etc/profile.d/rocm.sh`` that sets PATH and LD_LIBRARY_PATH for interactive
+  shells, and explicitly updates ``/root/.bashrc`` for non-interactive SSH
+  sessions used by CIJOE.
+
+steps:
+- name: amdgpu_install_script
+  run: |
+    wget -O workdir/amdgpu-install.deb {{ config.amd.amdgpu_install.url }}
+    apt-get install -y ./workdir/amdgpu-install.deb
+    apt-get update
+
+- name: amdgpu_driver
+  run: |
+    amdgpu-install -y --usecase=rocm
+
+- name: reboot
+  run: shutdown -r now
+
+- name: wait_down
+  uses: core.wait_for_transport
+  with:
+    state: down
+    timeout: 60
+
+- name: wait_up
+  uses: core.wait_for_transport
+  with:
+    state: up
+    timeout: 300
+
+- name: headless_tweaks
+  run: |
+    echo "options amdgpu runpm=0" | tee /etc/modprobe.d/amdgpu-headless.conf
+    update-initramfs -u
+
+- name: gpu_access
+  run: |
+    usermod -a -G video,render odus
+
+- name: verify_amdgpu
+  run: |
+    dkms status | grep amdgpu
+    lsmod | grep amdgpu
+    dmesg | grep -i amdgpu | tail -20
+
+- name: rocm_profile
+  run: |
+    echo '# ROCm environment variables (set by setup script)' | tee /etc/profile.d/rocm.sh
+    echo 'export PATH=/opt/rocm/bin:$PATH' | tee -a /etc/profile.d/rocm.sh
+    echo 'export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH' | tee -a /etc/profile.d/rocm.sh
+    chmod +x /etc/profile.d/rocm.sh
+    grep -qF 'SSH_CONNECTION' /root/.bashrc || sed -i '1i if [ -n "$SSH_CONNECTION" ] && [ -f /etc/profile.d/rocm.sh ]; then\n    . /etc/profile.d/rocm.sh\nfi\n' /root/.bashrc
+
+- name: verify_rocm
+  run: |
+    rocminfo
+    rocm-smi
+    hipcc --version
+
+- name: gpu_burn_install
+  run: |
+    apt-get install -y rocm-validation-suite
+    rvs -g
+
+- name: gpu_burn
+  run: |
+    ls /opt/rocm/share/rocm-validation-suite/conf/
+    rvs -c /opt/rocm/share/rocm-validation-suite/conf/gst_single.conf

--- a/tasks/setup_nvstack.yaml
+++ b/tasks/setup_nvstack.yaml
@@ -1,13 +1,13 @@
 doc: |
   Ubuntu 24.04 Setup of the NVIDIA Software Stack
-  ===============================================
+  ================================================
 
   This workflow provisions a system with the NVIDIA software stack required for
   NVMe <-> GPU development, testing, and experimentation. It targets the following
   components and versions:
 
-  * Ubuntu Server 24.04.3
-  * Linux 6.8 GA kernel (HWE must be disabled) / Linux 6.8 UDMABUF-IMPORT Kernel
+  * Ubuntu Server 24.04.4
+  * Linux 6.8 GA kernel (HWE must be disabled)
   * NVIDIA Open Kernel Modules (NOKM) v570 (via apt)
   * CUDA Toolkit v12.8 (via apt)
   * CUDA Samples v12.8 (from source)
@@ -15,99 +15,33 @@ doc: |
       - DOCA_OFED does not include NVMe or GDS support
   * nvidia-fs (via apt)
 
-  The workflow also configures `PATH` and `LD_LIBRARY_PATH` to include the CUDA
-  toolkit.
-
-  Version information comes from two places:
-  * Apt repositories provide the minor versions of NOKM and CUDA.
-  * Major versions are fixed in the workflow itself and do not change automatically.
-
-  This workflow does *not* install Ubuntu. Instead, it assumes a clean Ubuntu Server
-  24.04.3 installation prepared with the selections shown below.
-
-  Base Ubuntu Installation
-  ------------------------
-  During installation, ensure the following:
-
-  * Kernel selection:
-      (X) GA Kernel
-      ( ) HWE Kernel  ← must be disabled
-
-  * Installation Base:
-      (X) Ubuntu Server
-      ( ) Ubuntu Server (minimized)
-
-  * Storage (guided):
-      (X) Use an entire disk
-      [ ] Set up this disk as an LVM group
-
-  * Profile:
-      - Your name: Odus | sudO
-      - Server name: aisio-nvstack-01
-      - Username: odus
-      - Password: <choose>
-
-  * SSH configuration:
-      [X] Install OpenSSH server
-
-  Required Manual Steps Before Running the Workflow
-  -------------------------------------------------
-  To allow CIJOE to execute commands as `root`, enable SSH root login:
-
-      sudo passwd root
-      sudo sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-      sudo systemctl restart ssh
-
-  Perform these steps only on a development machine, as enabling root SSH access
-  reduces system security.
+  This workflow assumes that the base Ubuntu preparation has already been
+  completed using ``setup_ubuntu.yaml``.
 
   Running the Workflow
   --------------------
-  After installing Ubuntu and enabling root SSH access, run:
+  After running ``setup_ubuntu.yaml``, run:
 
       cijoe --monitor \
         -c configs/transport.toml \
         -c configs/nvstack.toml \
         tasks/setup_nvstack.yaml
 
-  Make sure `transport.toml` contains the correct hostname and login credentials
-  for the root user.
+  Make sure ``transport.toml`` contains the correct hostname and login
+  credentials for the root user.
 
   Caveat: CUDA Environment
   ------------------------
   CUDA is not installed in standard system locations. The workflow installs a
-  helper script in `/etc/profile.d/cuda.sh` that sets the CUDA environment for
+  helper script in ``/etc/profile.d/cuda.sh`` that sets the CUDA environment for
   interactive shells.
 
   However, non-interactive shells (including many CIJOE operations) do *not*
-  automatically source `/etc/profile.d/`. The workflow therefore explicitly
-  updates `/root/.bashrc` so that CUDA tools (e.g., `nvcc`) work when executing
-  over SSH.
+  automatically source ``/etc/profile.d/``. The workflow therefore explicitly
+  updates ``/root/.bashrc`` so that CUDA tools (e.g., ``nvcc``) work when
+  executing over SSH.
 
 steps:
-- name: directories
-  run: |
-    mkdir -p {git,workdir}
-
-- name: disable_upgrades
-  run: |
-    systemctl stop unattended-upgrades || true
-    systemctl disable unattended-upgrades || true
-    systemctl mask unattended-upgrades || true
-    apt-get remove unattended-upgrades || true
-
-- name: packages
-  run: |
-    apt-get -qy update && apt-get -qy upgrade
-    apt-get -qy install build-essential linux-headers-$(uname -r) linux-tools-common linux-tools-$(uname -r) wget git htop vim cmake stress-ng parallel sysstat time
-    apt-get -qy autoremove
-
-- name: blacklist_nouveau
-  run: |
-    echo "blacklist nouveau" | tee /etc/modprobe.d/disable-nouveau.conf
-    echo "options nouveau modeset=0" | tee -a /etc/modprobe.d/disable-nouveau.conf
-    update-initramfs -u
-
 - name: ofed
   run: |
     wget -O workdir/ofed.tgz {{ config.nvidia.ofed.url }}

--- a/tasks/setup_nvstack_from_source.yaml
+++ b/tasks/setup_nvstack_from_source.yaml
@@ -39,7 +39,7 @@ doc: |
   * Profile Configuration
 
     - Your name: Odus | sudO
-    - Your servers name: aisio-nvstack-01
+    - Your servers name: aisio
     - Pick a username: odus
     - Password: ...
 

--- a/tasks/setup_ubuntu.yaml
+++ b/tasks/setup_ubuntu.yaml
@@ -1,0 +1,103 @@
+doc: |
+  Ubuntu 24.04 Preparation for AiSIO Software Stack
+  =================================================
+
+  Regardless of whether you will be using NVIDIA, AMD, or some other
+  GPU/Accelerators, then there is the general task of ensuring that the OS is
+  setup properly along with common tooling. This is provided here as a general
+  reference.
+  
+  Then the vendor-specifics are provided as different setup tasks. The general
+  portion targets the following components and versions:
+
+  * Ubuntu Server 24.04.4
+  * Linux 6.8 GA kernel (HWE must be disabled) / Linux 6.8 UDMABUF-IMPORT Kernel
+
+  This workflow does *not* install Ubuntu. Instead, it assumes a clean Ubuntu Server
+  24.04.4 installation prepared with the selections shown below.
+
+  Base Ubuntu Installation
+  ------------------------
+  During installation, ensure the following:
+
+  * Kernel selection:
+      (X) GA Kernel
+      ( ) HWE Kernel  ← must be disabled
+
+  * Installation Base:
+      (X) Ubuntu Server
+      ( ) Ubuntu Server (minimized)
+
+  * Storage (guided):
+      (X) Use an entire disk
+      [ ] Set up this disk as an LVM group
+
+  * Profile:
+      - Your name: Odus | sudO
+      - Server name: aisio
+      - Username: odus
+      - Password: <choose>
+
+  * SSH configuration:
+      [X] Install OpenSSH server
+
+  Required Manual Steps Before Running the Workflow
+  -------------------------------------------------
+  To allow CIJOE to execute commands as `root`, enable SSH root login:
+
+      sudo passwd root
+      sudo sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      sudo systemctl restart ssh
+
+  Perform these steps only on a development machine, as enabling root SSH access
+  reduces system security.
+
+  Running the Workflow
+  --------------------
+  After installing Ubuntu and enabling root SSH access, run:
+
+      cijoe --monitor \
+        -c configs/transport.toml \
+        tasks/setup_ubuntu.yaml
+
+  Make sure `transport.toml` contains the correct hostname and login credentials
+  for the root user.
+
+steps:
+- name: directories
+  run: |
+    mkdir -p {git,workdir}
+
+- name: disable_upgrades
+  run: |
+    systemctl stop unattended-upgrades || true
+    systemctl disable unattended-upgrades || true
+    systemctl mask unattended-upgrades || true
+    apt-get remove unattended-upgrades || true
+
+- name: packages
+  run: |
+    apt-get -qy update && apt-get -qy upgrade
+    apt-get -qy install build-essential linux-headers-$(uname -r) linux-tools-common linux-tools-$(uname -r) wget git htop vim cmake stress-ng parallel sysstat time environment-modules python3-setuptools python3-wheel meson
+    apt-get -qy autoremove
+
+- name: blacklist_nouveau
+  run: |
+    echo "blacklist nouveau" | tee /etc/modprobe.d/disable-nouveau.conf
+    echo "options nouveau modeset=0" | tee -a /etc/modprobe.d/disable-nouveau.conf
+    update-initramfs -u
+
+- name: reboot
+  run: shutdown -r now
+
+- name: wait_down
+  uses: core.wait_for_transport
+  with:
+    state: down
+    timeout: 60
+
+- name: wait_up
+  uses: core.wait_for_transport
+  with:
+    state: up
+    timeout: 300


### PR DESCRIPTION
Extract common Ubuntu 24.04 preparation steps (packages, nouveau blacklist, directories) from ``setup_nvstack.yaml`` into a shared ``setup_ubuntu.yaml`` workflow. Both NVIDIA and AMD vendor-specific workflows now assume this base preparation has been run first, eliminating duplication.

Add ``setup_amdstack.yaml`` for installing amdgpu-dkms and ROCm 7.2 on Ubuntu 24.04. The workflow follows the same pattern as ``setup_nvstack.yaml`` and includes headless tweaks, video/render group setup, ROCm environment configuration, and GPU stress testing via the ROCm Validation Suite.