### PR TITLE
feat(homi): add configs, linkage, init for xnvme and xallib

### DIFF
--- a/homi/Makefile
+++ b/homi/Makefile
@@ -50,3 +50,10 @@ endef
 .PHONY: log
 log:
 	journalctl -u homi -n10
+
+define status-help
+# Run systemctl status homi
+endef
+.PHONY: status
+status:
+	systemctl status homi || :

--- a/homi/README.md
+++ b/homi/README.md
@@ -44,3 +44,13 @@ journalctl -u homi
 # or
 journalctl -u homi -n30
 ```
+
+## Status
+
+Check if the daemon is running or stopped. Simplified with make.
+
+```bash
+make status
+# or
+systemctl status homi
+```

--- a/homi/config/homi.conf.in
+++ b/homi/config/homi.conf.in
@@ -9,3 +9,11 @@ devices = [ ]
 
 # IPC socket
 ipc_socket = "/run/homi/homi.sock"
+
+[xal]
+# xfs = 1, fiemap = 2
+backend = 2
+# none = 0, dirty detection = 1, extent update = 2
+watchmode = 2
+# traverse = 0, hashmap = 1
+file_lookupmode = 0

--- a/homi/include/homid.h
+++ b/homi/include/homid.h
@@ -1,3 +1,5 @@
 struct homid {
   struct homid_ipc_connection *conn;
+  struct homid_device *dev;	///< Pointer to array of 'struct homid_device'
+  unsigned int ndevs;		///< Number of devices
 };

--- a/homi/include/homid_opts.h
+++ b/homi/include/homid_opts.h
@@ -2,9 +2,10 @@
 
 struct homid_opts {
 	int log_level;
-	int ndevs;
+	unsigned int ndevs;
 	char (*dev_uris)[HOMID_DEVURI_MAXLEN];
 	char *ipc_socket;
+	struct xal_opts xal_opts;
 };
 
 /**
@@ -13,6 +14,10 @@ struct homid_opts {
  * We expect the configuration file to have keys:
  * - log_level (int)
  * - devices (array of strings)
+ * - ipc_socket (string)
+ * - xal.backend (int)
+ * - xal.watchmode (int)
+ * - xal.file_lookupmode (int)
  *
  * @param path Path to the configuration file
  * @param opts homid_opts struct that the configuration will be loaded into

--- a/homi/include/homid_xal.h
+++ b/homi/include/homid_xal.h
@@ -1,0 +1,57 @@
+struct homid_opts;
+
+struct homid_device {
+	struct xnvme_dev *dev;
+	struct xal *xal;
+};
+
+/**
+ * Setup xal for the homid_device
+ *
+ * For the given homid_device, open xal and retrieve extents through a full scan.
+ * xnvme device must be initialized first.
+ *
+ * @param opts		xal_opts parsed from config file.
+ * @param device	Output: device to setup.
+ * @return			0 on success, negative errno on failure.
+ */
+int
+homid_xal_setup(struct xal_opts *opts, struct homid_device *device);
+
+/**
+ * Setup xnvme for the homid_device
+ *
+ * For the given homid_device, initialize xnvme.
+ * Uses default xnvme_opts with "linux" as backend.
+ *
+ * @param uri		URI of the device.
+ * @param device	Output: device to setup.
+ * @return			0 on success, negative errno on failure.
+ */
+int
+homid_xnvme_setup(char *uri, struct xnvme_dev **device);
+
+/**
+ * Cleans up array of homid_device
+ *
+ * For the given number of devices, clean each homid_device's xal and xvnme setups.
+ * Checks before freeing.
+ *
+ * @param ndevs		Number of devices to clean.
+ * @param devices	Array of homid_device to clean.
+ */
+void
+homid_device_close(unsigned int ndevs, struct homid_device *devices);
+
+/**
+ * Setup array of homid_device
+ *
+ * Allocates array of homid_device and initializes xnvme and xal for each of them.
+ * Uses device uri, ndevs, and xal_opts from user config options.
+ *
+ * @param opts		config options parsed from user config file.
+ * @param devices	Output: array of homid_device to setup.
+ * @return			0 on success, negative errno on failure.
+ */
+int
+homid_device_setup(struct homid_opts *opts, struct homid_device **devices);

--- a/homi/meson.build
+++ b/homi/meson.build
@@ -13,12 +13,21 @@ systemd = dependency('systemd')
 toml = subproject('tomlc17')
 toml_dep = toml.get_variable('toml_dep')
 
-homi_dependencies = [toml_dep]
+xal_dep = dependency('xal', method: 'pkg-config', required: true)
+
+xnvme_dep = dependency('xnvme', method: 'pkg-config', required: true)
+
+homi_dependencies = [
+	toml_dep,
+	xal_dep,
+	xnvme_dep
+]
 
 sources = files(
   'src/homid.c',
   'src/homid_ipc.c',
   'src/homid_log.c',
+  'src/homid_xal.c',
   'src/homid_opts.c',
   'src/homi_proto.c',
 )

--- a/homi/src/homid.c
+++ b/homi/src/homid.c
@@ -7,11 +7,13 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <libxal.h>
+
 #include <homid.h>
 #include <homid_ipc.h>
 #include <homid_log.h>
+#include <homid_xal.h>
 #include <homid_opts.h>
-
 
 volatile sig_atomic_t stop = 0;
 
@@ -67,9 +69,11 @@ homid_initialize(struct homid_opts *opts, struct homid **homid)
 		goto failed;
 	}
 
-	// For now, we just log the devices given in the configuration file.
-	for (int i = 0; i < opts->ndevs; i++) {
-		homid_log(LOG_NOTICE, "Device: %s", opts->dev_uris[i]);
+	cand->ndevs = opts->ndevs;
+	err = homid_device_setup(opts, &cand->dev);
+	if (err) {
+		homid_log(LOG_ERR, "Failed: homid_device_setup()");
+		goto failed;
 	}
 
 	*homid = cand;
@@ -88,6 +92,7 @@ homid_close(struct homid *homid) {
 		return 0;
 	}
 
+	homid_device_close(homid->ndevs, homid->dev);
 	homid_ipc_close(homid->conn);
 
 	return 0;

--- a/homi/src/homid_opts.c
+++ b/homi/src/homid_opts.c
@@ -3,7 +3,10 @@
 #include <string.h>
 #include <tomlc17.h>
 
+#include <libxal.h>
+
 #include <homid_log.h>
+#include <homid_xal.h>
 #include <homid_opts.h>
 
 static int
@@ -19,6 +22,7 @@ homid_opts_from_toml(char *config_file, struct homid_opts *opts)
 {
 	toml_result_t result;
 	toml_datum_t log_level, devices, ipc_socket;
+	toml_datum_t xal_backend, xal_watchmode, xal_file_lookupmode;
 	int err = 0;
 
 	result = toml_parse_file_ex(config_file);
@@ -73,7 +77,7 @@ homid_opts_from_toml(char *config_file, struct homid_opts *opts)
 	opts->dev_uris = malloc(devices.u.arr.size * sizeof(*opts->dev_uris));
 	if (!opts->dev_uris) {
 		err = -errno;
-		homid_log(LOG_ERR, "Faied: malloc(); errno(%d)", errno);
+		homid_log(LOG_ERR, "Failed: malloc(); errno(%d)", errno);
 		goto exit;
 	}
 
@@ -104,6 +108,59 @@ homid_opts_from_toml(char *config_file, struct homid_opts *opts)
 		goto exit;
 	}
 	strcpy(opts->ipc_socket, ipc_socket.u.s);
+
+	xal_backend = toml_seek(result.toptab, "xal.backend");
+	if (xal_backend.type != TOML_INT64) {
+		homid_log(LOG_ERR, "Missing or invalid 'xal.backend' property in config");
+		err = -EINVAL;
+		goto exit;
+	}
+
+	if (xal_backend.u.int64 == XAL_BACKEND_XFS) {
+		opts->xal_opts.be = XAL_BACKEND_XFS;
+	} else if (xal_backend.u.int64 == XAL_BACKEND_FIEMAP) {
+		opts->xal_opts.be = XAL_BACKEND_FIEMAP;
+	} else {
+		homid_log(LOG_ERR, "Missing or invalid 'xal.backend' property in config");
+		err = -EINVAL;
+		goto exit;
+	}
+
+	xal_watchmode = toml_seek(result.toptab, "xal.watchmode");
+	if (xal_watchmode.type != TOML_INT64) {
+		homid_log(LOG_WARNING, "Missing or invalid 'xal.watchmode' property in config");
+	}
+
+	switch (xal_watchmode.u.int64)
+	{
+	case 0:
+		opts->xal_opts.watch_mode = XAL_WATCHMODE_NONE;
+		break;
+	case 1:
+		opts->xal_opts.watch_mode = XAL_WATCHMODE_DIRTY_DETECTION;
+		break;
+	case 2:
+		opts->xal_opts.watch_mode = XAL_WATCHMODE_EXTENT_UPDATE;
+		break;
+	default:
+		homid_log(LOG_WARNING, "'xal.watchmode' defaulting to 'none'");
+		opts->xal_opts.watch_mode = XAL_WATCHMODE_NONE;
+		break;
+	}
+
+	xal_file_lookupmode = toml_seek(result.toptab, "xal.file_lookupmode");
+	if (xal_file_lookupmode.type != TOML_INT64) {
+		homid_log(LOG_WARNING, "Missing or invalid 'xal.file_lookupmode' property in config");
+	}
+
+	if (xal_file_lookupmode.u.int64 == XAL_FILE_LOOKUPMODE_TRAVERSE) {
+		opts->xal_opts.file_lookupmode = XAL_FILE_LOOKUPMODE_TRAVERSE;
+	} else if (xal_file_lookupmode.u.int64 == XAL_FILE_LOOKUPMODE_HASHMAP) {
+		opts->xal_opts.file_lookupmode = XAL_FILE_LOOKUPMODE_HASHMAP;
+	} else {
+		homid_log(LOG_WARNING, "'xal.file_lookupmode' defaulting to 'traverse'");
+		opts->xal_opts.file_lookupmode = XAL_FILE_LOOKUPMODE_TRAVERSE;
+	}
 
 exit:
 	toml_free(result);

--- a/homi/src/homid_xal.c
+++ b/homi/src/homid_xal.c
@@ -1,0 +1,130 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+
+#include <libxal.h>
+#include <libxnvme.h>
+
+#include <homid_log.h>
+#include <homid_xal.h>
+#include <homid_opts.h>
+
+int
+homid_xal_setup(struct xal_opts *opts, struct homid_device *device)
+{
+	struct xal *xal;
+	int err;
+
+	if (!device) {
+		err = -EINVAL;
+		homid_log(LOG_ERR, "No homid_device for xal setup: %d", err);
+		return err;
+	}
+
+	err = xal_open(device->dev, &xal, opts);
+	if (err) {
+		homid_log(LOG_ERR, "xal_open(): %d", err);
+		return err;
+	}
+
+	err = xal_dinodes_retrieve(xal);
+	if (err) {
+		homid_log(LOG_ERR, "xal_dinodes_retrieve(): %d", err);
+		goto close;
+	}
+
+	err = xal_index(xal);
+	if (err) {
+		homid_log(LOG_ERR, "xal_index(): %d", err);
+		goto close;
+	}
+
+	device->xal = xal;
+
+	return 0;
+
+close:
+	xal_close(xal);
+	return err;
+}
+
+int
+homid_xnvme_setup(char *uri, struct xnvme_dev **device)
+{
+	struct xnvme_opts opts = xnvme_opts_default();
+	struct xnvme_dev *dev;
+	int err;
+
+	opts.be = "linux";
+	dev = xnvme_dev_open(uri, &opts);
+	if (!dev) {
+		err = -errno;
+		homid_log(LOG_ERR, "xnvme_dev_open(): %d", err);
+		return err;
+	}
+
+	*device = dev;
+	return 0;
+}
+
+void
+homid_device_close(unsigned int ndevs, struct homid_device *devices)
+{
+	if (!devices) {
+		return;
+	}
+
+	for (unsigned int i = 0; i < ndevs; i++) {
+		struct homid_device *dev = &devices[i];
+
+		if (!dev) {
+			continue;
+		}
+
+		xal_close(dev->xal);
+
+		xnvme_dev_close(dev->dev);
+	}
+
+	free(devices);
+}
+
+int
+homid_device_setup(struct homid_opts *opts, struct homid_device **devices)
+{
+	struct xal_opts *xal_opts = &opts->xal_opts;
+	struct homid_device *devs;
+	unsigned int ndevs = opts->ndevs;
+	int err;
+
+	devs = calloc(ndevs, sizeof(struct homid_device *));
+	if (!devs) {
+		err = -errno;
+		homid_log(LOG_ERR, "Failed to allocate devices: %d", err);
+		return err;
+	}
+
+	for (unsigned int i = 0; i < ndevs; i++) {
+		char *uri = opts->dev_uris[i];
+
+		err = homid_xnvme_setup(uri, &devs[i].dev);
+		if (err) {
+			homid_log(LOG_ERR, "Failed to setup xNVMe for %s: %d", uri, err);
+			goto failed;
+		}
+
+		err = homid_xal_setup(xal_opts, &devs[i]);
+		if (err) {
+			homid_log(LOG_ERR, "Failed to setup XAL for %s: %d", uri, err);
+			goto failed;
+		}
+	}
+
+	*devices = devs;
+	return 0;
+
+failed:
+	homid_device_close(ndevs, devs);
+	return err;
+}


### PR DESCRIPTION
Parse xal options: backend, watchmode, file lookupmode.
Added files src/homid_xal.c and include/homid_xal.h

Assumes user cijoe'ed prior to building homi
Also added 'make status' for convenience

Setup xnvme and xal and init structures
Use default xnvme opts with linux backend