### PR TITLE
fix(configs/udmabuf): change repos. path to '/root/git'

### DIFF
--- a/configs/udmabuf_import.toml
+++ b/configs/udmabuf_import.toml
@@ -4,7 +4,7 @@ pkg = "linux-source-6.8.0"
 [udmabuf.repository]
 remote = "https://github.com/xnvme/udmabuf-import"
 branch = "main"
-path = "{{ local.env.HOME }}/git/udmabuf-import"
+path = "/root/git/udmabuf-import"
 
 [udmabuf.patch]
 name = "udmabuf-import-dma-buf-and-share-phys-addr-to-user.patch"


### PR DESCRIPTION
Changing this for two reasons:

* Align with the paths in the other configs assume that repositories live in '/root/git'.

* When using the task with a remote system then it is likely that 'local.env.home' does not properly reflect a path on the remote system, especially not when the remote system is setup as described in "setup_ubuntu".