### PR TITLE
Individual benchmark tool scripts

### DIFF
--- a/scripts/bdevperf.py
+++ b/scripts/bdevperf.py
@@ -1,0 +1,101 @@
+import json
+import logging as log
+from argparse import ArgumentParser
+from pathlib import Path
+
+
+REQUIRED_KEYS = ["cpumask", "iopattern", "qdepth", "iosize", "runtime", "config_path", "devices"]
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--devices", type=str, default=[], nargs="+")
+    parser.add_argument("--ndevs", type=int, default=0)
+    parser.add_argument("--iopattern", type=str, default="randread")
+    parser.add_argument("--qdepth", type=int, default=128)
+    parser.add_argument("--iosize", type=int, default=512)
+    parser.add_argument("--runtime", type=int, default=10)
+    parser.add_argument("--cpumask", type=str, default="0x1")
+
+
+def create_config(devices: list, path: Path) -> int:
+    """
+    Create a configuration json file for running bdevperf, following the format of
+    /path/to/spdk/test/bdev/bdevperf/conf.json
+    """
+
+    if path.exists():
+        return 0
+
+    subsystem = {
+        "subsystem": "bdev",
+        "config": []
+    }
+
+    for i, device in enumerate(devices):
+        item = {
+            "method": "bdev_nvme_attach_controller",
+            "params": {
+                "name": f"nvme{i:02d}",
+                "trtype": "PCIe",
+                "traddr": device
+            }
+        }
+        subsystem["config"].append(item)
+
+    with open(path, "x") as file:
+        json.dump({ "subsystems": [subsystem] }, file, indent=2)
+
+    return 0
+
+
+def bdevperf_cmd(bin: str, args: dict) -> str:
+    if any(key not in args for key in REQUIRED_KEYS):
+        log.error(f"Failed: Missing arguments for {bin}")
+
+    parameters = [
+        f"{bin}",
+        f"-c {args["config_path"]}",
+        f"-m {args["cpumask"]}",
+        f"-q {args["qdepth"]}",
+        f"-o {args["iosize"]}",
+        f"-t {args["runtime"]}",
+        f"-w {args["iopattern"]}",
+    ]
+    return " ".join(parameters)
+
+
+def main(args, cijoe):
+    if bool(args.devices) == bool(args.ndevs):
+        log.error(
+            "Failed: Exactly one of arguments 'devices' and 'ndevs' must be defined; "
+            f"got devices({args.devices}), ndevs({args.ndevs})"
+        )
+        return -1
+
+    if args.ndevs:
+        devs = cijoe.getconf("devices", None)
+        args.devices = [d["pci_addr"] for d in devs[:args.ndevs]]
+
+    config_path = Path(args.output) / cijoe.output_ident / "bdevperf_config.json"
+
+    spdk_path = cijoe.getconf("spdk.repository.path", None)
+    if not spdk_path:
+        log.error("Failed: Missing SPDK repository path in config")
+        return
+
+    bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
+
+    err = create_config(args.devices, config_path)
+    if err:
+        log.error("Failed: create_config()")
+        return err
+
+    args.config_path = "/tmp/bdevperf_config.json"
+
+    # If run on remote, cijoe.put is necessary
+    cijoe.put(config_path, args.config_path)
+
+    cmd = bdevperf_cmd(bin, vars(args))
+    err, _ = cijoe.run(cmd)
+
+    return err

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -31,6 +31,7 @@ import json
 import logging as log
 
 from bdevperf import bdevperf_cmd, create_config as bdevperf_config
+from spdk_nvme_perf import spdk_nvme_perf_cmd
 from xnvmeperf import xnvmeperf_cmd
 
 
@@ -63,13 +64,16 @@ class BenchHelper():
         self.remote_config = Path("/tmp/bdevperf-config.json")
         self.devices: list = cijoe.getconf("devices")
 
-        if tool == "bdevperf":
+        if tool in ["bdevperf", "spdk_nvme_perf"]:
             spdk_path = self.cijoe.getconf("spdk.repository.path", None)
             if not spdk_path:
                 log.error("Failed: Missing SPDK repository path in config")
                 return
 
-            self.bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
+            if tool == "bdevperf":
+                self.bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
+            else:
+                self.bin = Path(spdk_path)  / "build" / "bin" / "spdk_nvme_perf"
         elif tool == "xnvmeperf":
             self.bin = "xnvmeperf"
         else:
@@ -137,6 +141,9 @@ class BenchHelper():
 
             bench_args["config_path"] = self.remote_config
             command += bdevperf_cmd(self.bin, bench_args)
+
+        elif self.tool == "spdk_nvme_perf":
+            command += spdk_nvme_perf_cmd(self.bin, bench_args)
 
         elif self.tool == "xnvmeperf":
             bench_args["backend"] = self.backend
@@ -270,6 +277,8 @@ class BenchHelper():
 
         if self.tool == "bdevperf":
             table_regex = r"\s*(?P<name>\w+)\s+:\s+(?P<runtime>[0-9.]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)\s+(?P<tos>[0-9.]+)\s+(?P<avg_lat>[0-9.]+)\s+(?P<min_lat>[0-9.]+)\s+(?P<max_lat>[0-9.]+)"
+        elif self.tool == "spdk_nvme_perf":
+            table_regex = r"\s*(?P<name>.+?)\s*?:\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<avg_lat>[0-9.]+)\s+(?P<min_lat>[0-9.]+)\s+(?P<max_lat>[0-9.]+)"
         elif self.tool == "xnvmeperf":
             table_regex = r"\s*(?P<name>\w+):?\s+(?P<cpus>[0-9,]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)"
         else:

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -30,6 +30,9 @@ from typing import Tuple
 import json
 import logging as log
 
+from bdevperf import bdevperf_cmd, create_config as bdevperf_config
+from xnvmeperf import xnvmeperf_cmd
+
 
 class BenchHelper():
     def __init__(
@@ -68,7 +71,7 @@ class BenchHelper():
 
             self.bin = Path(spdk_path) / "build" / "examples" / "bdevperf"
         elif tool == "xnvmeperf":
-            self.bin = "xnvmeperf run"
+            self.bin = "xnvmeperf"
         else:
             log.error(f"Failed: Unknown tool({tool})")
 
@@ -116,47 +119,34 @@ class BenchHelper():
                 result = json.load(file)
                 return 0, result
 
+        bench_args = {
+            "cpumask": self.cpu_masks[ncpus],
+            "iopattern": "randread",
+            "qdepth": depth,
+            "iosize": size,
+            "runtime": time,
+            "devices": [d["pci_addr"] for d in self.devices[0:ndevs]],
+        }
+
+        command = f"/usr/bin/time "
+
         if self.tool == "bdevperf":
             config_local_path = self.configs_path / f"d{ndevs}.json"
-            self._create_bdevperf_config(self.devices[0:ndevs], config_local_path)
+            bdevperf_config(bench_args["devices"], config_local_path)
             self.cijoe.put(config_local_path, self.remote_config)
 
-        mask = self.cpu_masks[ncpus]
-        selected_cpus = [v[0] for v in self.cpu_pairs if int(mask, 16) & (1 << v[0])]
+            bench_args["config_path"] = self.remote_config
+            command += bdevperf_cmd(self.bin, bench_args)
 
-        self.cfm.set_cpu_freq(cpu_freq, selected_cpus)
-
-        err = self.cfm.start_logging()
-        if err:
-            log.error("Failed: CpuFrequencyHelper.start_logging()")
-            return err, None
-
-        command = f"/usr/bin/time {self.bin} "
-
-        if self.tool == "bdevperf":
-            run_parameters = [
-                f"-c {self.remote_config}",
-                f"-m {mask}",
-                f"-q {depth}",
-                f"-o {size}",
-                f"-t {time}",
-                "-w randread"
-            ]
-            command += " ".join(run_parameters)
         elif self.tool == "xnvmeperf":
-            run_parameters = [
-                f"--cpumask {mask}",
-                f"--qdepth {depth}",
-                f"--iosize {size}",
-                f"--runtime {time}",
-                "--iopattern randread",
-                f"--be {self.backend}",
-                " ".join(d["pci_addr"] for d in self.devices[0:ndevs]),
-            ]
-            command += " ".join(run_parameters)
+            bench_args["backend"] = self.backend
+            command += xnvmeperf_cmd(self.bin, bench_args)
+
         else:
-            log.error(f"Unkown tool: {self.tool}")
+            log.error(f"Unknown tool: {self.tool}")
             return -1
+
+        selected_cpus = [v[0] for v in self.cpu_pairs if int(bench_args["cpumask"], 16) & (1 << v[0])]
 
         if self.stress and (stressed_cpus := [str(x) for x in range(len(self.cpu_pairs)) if x not in selected_cpus]):
             command = "\n".join([
@@ -165,6 +155,12 @@ class BenchHelper():
                 command,
                 "wait $STRESS_PID",
             ])
+
+        self.cfm.set_cpu_freq(cpu_freq, selected_cpus)
+        err = self.cfm.start_logging()
+        if err:
+            log.error("Failed: CpuFrequencyHelper.start_logging()")
+            return err, None
 
         err, state = self.cijoe.run(command)
         if err:
@@ -257,36 +253,6 @@ class BenchHelper():
 
         self.cpu_masks = cpu_masks
         self.cpu_pairs = cpu_pairs
-
-        return 0
-
-    def _create_bdevperf_config(self, devices: list, path: Path) -> int:
-        """
-        Create a configuration json file for running bdevperf, following the format of
-        /path/to/spdk/test/bdev/bdevperf/conf.json
-        """
-
-        if path.exists():
-            return 0
-
-        subsystem = {
-            "subsystem": "bdev",
-            "config": []
-        }
-
-        for i, device in enumerate(devices):
-            item = {
-                "method": "bdev_nvme_attach_controller",
-                "params": {
-                    "name": f"nvme{i:02d}",
-                    "trtype": "PCIe",
-                    "traddr": device["pci_addr"]
-                }
-            }
-            subsystem["config"].append(item)
-
-        with open(path, "x") as file:
-            json.dump({ "subsystems": [subsystem] }, file, indent=2)
 
         return 0
 

--- a/scripts/bench_runall.py
+++ b/scripts/bench_runall.py
@@ -38,7 +38,7 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--time", type=int, default=10, help="Time for for bdevperf to run for each test")
     parser.add_argument("--results_dir", type=Path, default=None, help="Path to existing directory in which the results should be saved. Note: Already existing results will not be benchmarked again")
     parser.add_argument("--repetitions", type=int, default=5, help="The amount of times each benchmark will be repeated. The result will be average of the repetitions")
-    parser.add_argument("--tool", choices=["bdevperf", "xnvmeperf"], default="xnvmeperf")
+    parser.add_argument("--tool", choices=["bdevperf", "xnvmeperf", "spdk_nvme_perf"], default="xnvmeperf")
     parser.add_argument("--backend", type=str, default="upcie")
 
 

--- a/scripts/spdk_nvme_perf.py
+++ b/scripts/spdk_nvme_perf.py
@@ -1,0 +1,57 @@
+import logging as log
+from argparse import ArgumentParser
+from pathlib import Path
+
+
+REQUIRED_KEYS = ["cpumask", "iopattern", "qdepth", "iosize", "runtime", "devices"]
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--devices", type=str, default=[], nargs="+")
+    parser.add_argument("--ndevs", type=int, default=0)
+    parser.add_argument("--iopattern", type=str, default="randread")
+    parser.add_argument("--qdepth", type=int, default=128)
+    parser.add_argument("--iosize", type=int, default=512)
+    parser.add_argument("--runtime", type=int, default=10)
+    parser.add_argument("--cpumask", type=str, default="0x1")
+
+
+def spdk_nvme_perf_cmd(bin: str, args: dict) -> str:
+    if any(key not in args for key in REQUIRED_KEYS):
+        log.error(f"Failed: Missing arguments for {bin}")
+
+    parameters = [
+        f"{bin}",
+        f"-c {args["cpumask"]}",
+        f"-q {args["qdepth"]}",
+        f"-o {args["iosize"]}",
+        f"-t {args["runtime"]}",
+        f"-w {args["iopattern"]}",
+        " ".join(f'-r "trtype:PCIe traddr:{d}"' for d in args["devices"]),
+    ]
+    return " ".join(parameters)
+
+
+def main(args, cijoe):
+    if bool(args.devices) == bool(args.ndevs):
+        log.error(
+            "Failed: Exactly one of arguments 'devices' and 'ndevs' must be defined; "
+            f"got devices({args.devices}), ndevs({args.ndevs})"
+        )
+        return -1
+
+    if args.ndevs:
+        devs = cijoe.getconf("devices", None)
+        args.devices = [d["pci_addr"] for d in devs[:args.ndevs]]
+
+    spdk_path = cijoe.getconf("spdk.repository.path", None)
+    if not spdk_path:
+        log.error("Failed: Missing SPDK repository path in config")
+        return
+
+    bin = Path(spdk_path) / "build" / "bin" / "spdk_nvme_perf"
+
+    cmd = spdk_nvme_perf_cmd(bin, vars(args))
+    err, _ = cijoe.run(cmd)
+
+    return err

--- a/scripts/xnvmeperf.py
+++ b/scripts/xnvmeperf.py
@@ -1,0 +1,52 @@
+import logging as log
+from argparse import ArgumentParser
+
+
+REQUIRED_KEYS = ["cpumask", "iopattern", "qdepth", "iosize", "runtime", "backend", "devices"]
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--devices", type=str, default=[], nargs="+")
+    parser.add_argument("--ndevs", type=int, default=0)
+    parser.add_argument("--iopattern", type=str, default="randread")
+    parser.add_argument("--qdepth", type=int, default=128)
+    parser.add_argument("--iosize", type=int, default=512)
+    parser.add_argument("--runtime", type=int, default=10)
+    parser.add_argument("--cpumask", type=str, default="0x1")
+    parser.add_argument("--backend", type=str, default="upcie")
+
+
+def xnvmeperf_cmd(bin: str, args: dict) -> str:
+    if any(key not in args for key in REQUIRED_KEYS):
+        log.error(f"Failed: Missing arguments for {bin}")
+
+    parameters = [
+        f"{bin}",
+        "run",
+        f"--cpumask {args["cpumask"]}",
+        f"--qdepth {args["qdepth"]}",
+        f"--iosize {args["iosize"]}",
+        f"--runtime {args["runtime"]}",
+        f"--iopattern {args["iopattern"]}",
+        f"--be {args["backend"]}",
+        " ".join(args["devices"]),
+    ]
+    return " ".join(parameters)
+
+
+def main(args, cijoe):
+    if bool(args.devices) == bool(args.ndevs):
+        log.error(
+            "Failed: Exactly one of arguments 'devices' and 'ndevs' must be defined; "
+            f"got devices({args.devices}), ndevs({args.ndevs})"
+        )
+        return -1
+
+    if args.ndevs:
+        devs = cijoe.getconf("devices", None)
+        args.devices = [d["pci_addr"] for d in devs[:args.ndevs]]
+
+    cmd = xnvmeperf_cmd("xnvmeperf", vars(args))
+    err, _ = cijoe.run(cmd)
+
+    return err

--- a/tasks/bench_tools.yaml
+++ b/tasks/bench_tools.yaml
@@ -1,0 +1,73 @@
+doc: |
+  Run the different benchmark tools
+  =================================
+
+  Run the different benchmarking tools with the same parameters.
+
+  Binding to userspace
+  --------------------
+  This scripts assumes if the boot device is an NVMe device, then the `xnvme.driver.prefix`
+  variable has been defined to add the device's PCIe address to the PCI_BLACKLIST env var
+  for the xnvme-driver script. Example:
+
+    [xnvme.driver]
+    prefix = "PCI_BLACKLIST=0000:01:00.0"
+
+  It's important that if the boot device is also an NVMe device that it's added in the
+  `PCI_BLACKLIST` in step "bind_to_userspace", since the xnvme-driver script otherwise
+  will unbind it, making the machine unusable (until next reboot).
+
+  It is not necessary to run this step if the workflow is run repeatedly.
+
+steps:
+- name: allocate_hugepages
+  run: |
+    sysctl -w vm.nr_hugepages=1024
+    mkdir -p /dev/hugepages
+    mountpoint -q /dev/hugepages || mount -t hugetlbfs nodev /dev/hugepages
+
+- name: bind_to_userspace
+  run: |
+    {{ config.xnvme.driver.prefix }} xnvme-driver
+
+- name: bdevperf
+  uses: bdevperf
+  with:
+    ndevs: &ndevs 16
+    iopattern: &iopattern randread
+    qdepth: &qdepth 128
+    iosize: &iosize 512
+    runtime: &runtime 10
+    cpumask: &cpumask "0x1" # "0x2000000000002" for thread sibling
+
+- name: spdk_nvme_perf
+  uses: spdk_nvme_perf
+  with:
+    ndevs: *ndevs
+    iopattern: *iopattern
+    qdepth: *qdepth
+    iosize: *iosize
+    runtime: *runtime
+    cpumask: *cpumask
+
+- name: xnvmeperf_spdk
+  uses: xnvmeperf
+  with:
+    ndevs: *ndevs
+    iopattern: *iopattern
+    qdepth: *qdepth
+    iosize: *iosize
+    runtime: *runtime
+    cpumask: *cpumask
+    backend: spdk
+
+- name: xnvmeperf_upcie
+  uses: xnvmeperf
+  with:
+    ndevs: *ndevs
+    iopattern: *iopattern
+    qdepth: *qdepth
+    iosize: *iosize
+    runtime: *runtime
+    cpumask: *cpumask
+    backend: upcie


### PR DESCRIPTION
I've added individual scripts for the three benchmarking tools bdevperf, spdk_nvme_perf and xnvmeperf, such that these can be used inside our larger benchmarking scripts, but also run individually inside of workflows.