### PR TITLE
docs: expand background with GPU terminology and cross-references

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -68,7 +68,7 @@ commands.
   path independently once the queues are established.
 
 **Buffer placement** describes where data buffers and queue structures reside,
-and determines whether peer-to-peer (P2P) DMA is involved.
+and determines whether peer-to-peer (P2P) DMA (see {ref}`sec-pcie`) is involved.
 
 - *Host memory*: data buffers reside in host DRAM. The NVMe controller performs
   DMA to and from host memory. When an accelerator needs the data, a separate

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -652,16 +652,13 @@ All NVMe specification documents are freely available upon ratification and
 distributed via the nvme express website. For details please to look in the
 specification documents, however, since these have now grown into many thousands
 of pages spread upon multiple documents, then see these subsections as a brief
-overview on theory of operations and NVMe initiatlization and command processing
+overview on theory of operations and NVMe initialization and command processing
 flows.
 
-Directly to the first concept an NVMe Controller, this is the entity which
-is accessible via a transport. Transports include, PCI, TCP, and RDMA. We are
-currently focused on the locally attached storage devices over PCI. Thus, thus
-initially we will cover how to initialize an NVMe controller over PCIe and touch
-upon PCIe infra. for it.
-
-On with it.
+An NVMe controller is the entity accessible via a transport. Transports include
+PCIe, TCP, and RDMA. We currently focus on locally attached storage devices over PCIe, with the
+intention to expand to other transports in the future. The following subsections
+cover controller initialization and command processing in that context.
 
 NVMe devices implement a command driven model in which the host constructs
 commands, places them in submission queues, and notifies the controller through

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -462,11 +462,188 @@ accelerator integrated storage paths.
 (sec-massively-parallel-processing-units)=
 ## Massively Parallel Processing Units
 
-* SIMD, SPMD, and SIMT
+Modern accelerators achieve high throughput by executing thousands of lightweight
+threads concurrently across many parallel compute units. Understanding how these
+threads are organized, scheduled, and provided with data is essential for
+reasoning about device-initiated I/O paths and the memory placement
+constraints they impose.
 
-* Arithmetic vs logic
+(sec-cuda)=
+### CUDA
 
-* Memory bandwidth vs Compute Capability
+CUDA (Compute Unified Device Architecture) is NVIDIA's parallel computing
+platform and programming model {cite}`hwu2022pmpp`. It exposes GPU hardware through a C-like
+programming interface that allows software to describe parallel computations as
+functions called **kernels**, which are launched on the GPU and execute across
+many threads simultaneously.
+
+#### Thread Hierarchy and Streaming Multiprocessors
+
+CUDA organizes threads into a three-level hierarchy under the **Single
+Instruction, Multiple Threads (SIMT)** execution model. Unlike SIMD, where a
+single instruction operates on a fixed-width vector of data in a single thread,
+SIMT issues a single instruction to a group of threads, each maintaining
+independent register state and a program counter.
+
+**Threads** are the smallest unit of execution in the SIMT model. Each thread
+has private registers and a unique position within its containing block and
+grid, expressed as `threadIdx`, `blockIdx`, and `blockDim` built-in variables.
+Threads are the granularity at which work is assigned and at which register
+state is maintained.
+
+**Thread blocks** (also called Cooperative Thread Arrays, or CTAs) are groups of
+threads that execute on the same compute unit and may cooperate through shared
+memory and explicit barrier synchronization. A thread block can contain up to
+1024 threads. The number of thread blocks that reside concurrently on a compute
+unit is limited by register and shared memory consumption.
+
+**Warps** are the fundamental unit of SIMT scheduling. A warp consists of 32
+threads that the hardware issues and executes as a single unit. Threads within
+a warp execute in lockstep under normal conditions, but may diverge when
+control flow differs, in which case inactive branches are masked until threads
+reconverge. While one warp stalls on a memory operation, the scheduler issues
+instructions from another ready warp, keeping execution units occupied.
+
+**Grids** are collections of thread blocks that together constitute a single
+kernel launch. Thread blocks within a grid execute independently and may be
+scheduled on any SM in any order. This independence is what enables kernels to
+scale across GPUs with varying numbers of SMs without requiring coordination
+between blocks.
+
+The **Streaming Multiprocessor (SM)** is the primary compute unit of a CUDA GPU.
+Each SM contains a warp scheduler, a register file partitioned among its active
+warps, and a configurable shared memory and L1 cache partition.
+
+#### Synchronization
+
+CUDA provides synchronization at multiple granularities. `__syncthreads()`
+inserts a barrier at the thread block level: all threads in the block must reach
+the barrier before any may proceed, ensuring that shared memory writes by one
+thread are visible to others. At the warp level, `__syncwarp()` synchronizes
+threads within a single warp and enforces memory ordering without the overhead
+of a full block barrier. For operations on shared or global memory that must be
+visible across threads without a full barrier, **memory fences**
+(`__threadfence_block()`, `__threadfence()`, `__threadfence_system()`) enforce
+ordering at block, device, and system scope respectively. **Atomic operations**
+on global and shared memory provide indivisible read-modify-write primitives,
+which are the primary mechanism for threads to coordinate on shared queue state
+without explicit barriers.
+
+#### Streams and Concurrency
+
+A **CUDA stream** is a sequence of operations, including kernel launches and
+memory copies, that execute in order on the device. Operations issued to
+different streams may overlap in time, subject to hardware resource availability.
+Streams are the primary mechanism for overlapping data transfers with kernel
+execution and for issuing independent workloads to separate hardware engines such
+as the copy engines and compute engines within a single GPU.
+
+#### Memory Hierarchy
+
+CUDA exposes a structured memory hierarchy that maps directly onto physical
+resources on the GPU.
+
+**Registers** are the fastest memory available to a thread. Each SM maintains a
+large register file that is partitioned among the active warps. Register pressure
+directly affects **occupancy**, the ratio of resident warps to the SM maximum,
+because the register file is a finite resource shared among all threads resident
+on an SM.
+
+**Shared memory** is an explicitly managed, low-latency on-chip SRAM pool shared
+among all threads within a thread block. It is physically the same SRAM as the
+L1 cache, with the partition between the two configurable in software. Shared
+memory enables fast communication between threads in the same block without going
+off-chip and is a primary mechanism for reuse and staging of data across
+cooperating threads.
+
+**L2 cache** is a device-wide cache shared across all SMs. It is significantly
+larger than per-SM L1 caches and serves as a second-level staging point for
+global memory accesses. The L2 cache is not directly addressable by software.
+
+**Global memory** is the main device-attached DRAM, typically implemented as
+GDDR or HBM depending on the product class. It is the largest memory pool
+available to a kernel, accessible by all threads in all blocks, and persists
+across kernel launches for the lifetime of an allocation. Access latency is
+hundreds of cycles, making coalesced access patterns and shared memory staging
+essential for sustaining high throughput.
+
+For device-initiated I/O, the memory tier in which a buffer resides
+determines whether the NVMe controller can reach it through DMA. Only global
+memory is directly addressable by PCIe peers; registers and shared memory are
+on-chip and invisible to devices outside the GPU. I/O payloads must therefore
+reside in global memory, and any staging through shared memory or registers
+must be completed before or after the transfer.
+
+#### CUDA APIs: Runtime and Driver
+
+CUDA exposes two programming interfaces. The **CUDA Runtime API** (`cuda*.h`)
+provides a higher-level, implicitly initialized interface. It manages device
+context creation automatically and is the interface used by most application code
+and libraries. The **CUDA Driver API** (`cuda.h`) is a lower-level interface that
+gives explicit control over device context creation, module loading, and kernel
+launch parameters. The runtime API is implemented on top of the driver API.
+
+#### Host and Device
+
+CUDA distinguishes two address spaces and two execution contexts. The **host**
+refers to the CPU and its attached DRAM. The **device** refers to the GPU and its
+attached memory. Code that runs on the CPU is host code; code annotated with
+`__global__` or `__device__` and launched on the GPU is device code.
+
+On platforms that support it, CUDA establishes a **Unified Virtual Address (UVA)**
+space that spans both host and device memory. Under UVA, every allocation —
+whether in host DRAM, device DRAM, or mapped through host registration — resides
+at a unique address within a single virtual address space shared by the CPU and
+GPU. This allows the runtime to determine from a pointer alone whether it refers
+to host or device memory, and is the mechanism that makes host registration and
+peer-to-peer addressing coherent across the two address spaces.
+
+Two allocation types reflect this separation. A **device allocation** resides in
+device memory and is not directly accessible from the host; data movement between
+the two traverses the PCIe interconnect unless the CPU and GPU share a unified
+physical memory substrate, as in some integrated and server architectures. A
+**unified allocation** is visible to both host and device through a single
+pointer, with the runtime managing migration on demand, at the cost of
+unpredictable transfer overhead.
+
+**Host registration** pins an existing memory region and maps it into the GPU's
+virtual address space, making it directly accessible from device code via load
+and store instructions. When applied to host DRAM, this is the CUDA equivalent
+of memory pinning: the physical pages are locked against relocation by the OS,
+and a device-accessible pointer is obtained through `cudaHostGetDevicePointer`.
+When applied to an MMIO region — such as the BAR of an NVMe controller — using
+the `cudaHostRegisterIoMemory` flag, the mapping gives GPU threads direct write
+access to device registers. This is the mechanism by which a GPU kernel can ring
+an NVMe submission queue doorbell without CPU involvement, and forms the basis of
+device-initiated I/O.
+
+The table below shows the runtime and driver API calls for the allocation and
+registration types described above.
+
+| Operation | Runtime API | Driver API |
+|---|---|---|
+| Device allocation | `cudaMalloc` | `cuMemAlloc` |
+| Unified allocation | `cudaMallocManaged` | `cuMemAllocManaged` |
+| Host registration | `cudaHostRegister` | `cuMemHostRegister` |
+
+#### Compute Capability
+
+NVIDIA identifies GPU microarchitecture generations and feature sets through a
+version number called **compute capability**. The major version number denotes
+the architecture generation (for example, 8 for Ampere, 9 for Hopper), and the
+minor version distinguishes variants within a generation. Compute capability
+determines which instructions are available, the SM register file size, the
+maximum shared memory per block, warp execution behavior, and support for
+features such as cooperative groups, asynchronous memory copies, and direct
+peer-to-peer memory access.
+
+Peer-to-peer memory access and MMIO region registration via
+`cudaHostRegisterIoMemory`, the two features central to device-initiated NVMe
+I/O, both require compute capability 3.5, introduced with the Kepler
+architecture in 2013. This requirement is satisfied by all modern CUDA-capable
+GPUs and is not a practical constraint. The binding limitation is instead
+platform-level peer-to-peer routing support, governed by PCIe topology and switch
+capabilities, as covered in {ref}`sec-pcie`.
 
 (sec-nvme-controllers)=
 ## NVMe Controllers

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -275,6 +275,7 @@ these memory addresses, which directly manipulate the state of the I/O device.
 Later we will take a closer look at thos PCIe attached devices expose register
 and memory spaces.
 
+(sec-pcie)=
 ## PCIe
 
 PCIe is a message-based interconnect anchored at the Root Complex (RC),
@@ -308,6 +309,11 @@ MMIO and DMA are both expressed on PCIe as Memory TLPs that differ only in
 initiator, direction, and size. All memory operations target host-physical
 addresses mapped to host RAM or device BARs and may originate from the CPU or
 from other PCIe endpoints.
+
+When a DMA transfer targets a peer endpoint's BAR address rather than host DRAM,
+the transfer bypasses host memory entirely. Such transfers are referred to as
+**peer-to-peer PCIe**. How they are routed through the fabric depends on which
+component performs the address decode, as described in the following subsections.
 
 This provides a simple mental model of PCIe. MMIO and DMA are both expressed as
 Memory TLPs that target host physical addresses which may lie in host memory or
@@ -357,8 +363,8 @@ corresponds to host memory or a device BAR.
 If the target lies within a peer device's BAR region, the RC forwards the
 request downstream through the appropriate Root Port. NVMe devices, GPUs, and
 NICs generate only address-routed Memory TLPs, so all their DMA traffic follows
-this pattern. Even zero-copy device-to-device transfers pass through the RC
-decode path unless the system uses a switch with address-translation hardware.
+this pattern. Even zero-copy peer-to-peer transfers pass through the RC decode path unless
+the system uses a switch with address-translation hardware.
 
 ### Routing: Switch Mediated
 
@@ -368,7 +374,7 @@ windows that allow the switch to match incoming host-physical addresses against
 configured ranges and forward Memory Requests directly downstream to another
 endpoint without involving the RC.
 
-This enables peer DMA within the switch fabric with reduced latency. However,
+This enables peer-to-peer DMA within the switch fabric with reduced latency. However,
 this is not part of the PCIe baseline specification. Only high-end switches
 used in multi-GGPU backplanes, multi-host fabrics, or accelerator systems expose
 ATUs, and translation windows must be programmed by firmware or the operating
@@ -386,13 +392,12 @@ A smaller class of endpoints can generate TLPs that use identifier routing
 instead of address routing. Such packets carry a Bus Device Function (BDF)
 identifier. Switches route these packets downstream by matching the BDF to
 the correct port. FPGAs, DPUs, NTBs, and a few accelerator ASICs can emit
-ID-routed Writes or Messages and therefore perform peer communication without
+ID-routed Writes or Messages and therefore perform peer-to-peer communication without
 RC involvement and without relying on switch ATUs. Commodity endpoints including
 NVMe SSDs, GPUs, and NICs do not generate ID-routed traffic and rely exclusively
 on address-routed Memory Requests.
 
 (sec-pcie-functions)=
-
 ### Multi-function devices
 
 PCIe devices are identified by a Bus–Device–Function (BDF) tuple. Under a single
@@ -446,11 +451,11 @@ domains at the level defined by the controller.
 Data movement in PCIe whether DMA or MMIO are sequences of Memory TLPs
 whose routing depends on which component performs the decode. Devices that
 generate address-routed TLPs rely on the RC unless a switch provides its own
-decode windows. Devices capable of ID-routed TLPs can perform peer routing
+decode windows. Devices capable of ID-routed TLPs can perform peer-to-peer routing
 independently. IOMMU translation, ATS caching, and ATC entries determine how
 devices obtain the addresses they use, but they do not alter the routing model.
-Together, RC mediated DMA, switch mediated peer DMA, and device routed peer DMA
-describe all data transfer paths allowable in PCI Express systems and form the
+Together, RC mediated DMA, switch mediated peer-to-peer DMA, and device-routed
+peer-to-peer DMA describe all data transfer paths allowable in PCI Express systems and form the
 architectural foundation for understanding performance and design tradeoffs in
 accelerator integrated storage paths.
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -42,7 +42,7 @@ entirely.
 Independent of software overhead, accelerator workloads suffer from redundant
 data movement. When a GPU requires data from storage, the conventional path
 routes it through host DRAM: the NVMe controller writes to host memory, and a
-separate copy transfers the data to GPU memory. Peer-to-peer (P2P) DMA
+separate copy transfers the data to GPU memory. Peer-to-peer (P2P) DMA (see {ref}`sec-pcie`)
 eliminates this intermediate copy by allowing the NVMe controller to transfer
 data directly to GPU memory over the PCIe fabric.
 

--- a/docs/src/references.bib
+++ b/docs/src/references.bib
@@ -284,6 +284,15 @@ keywords = {Resource sharing, composable infrastructure, I/O disaggregation, NTB
   note         = {Describes NVIDIA platforms such as DGX systems, Jetson devices, and DPU environments that rely on Linux as the foundational operating system}
 }
 
+@book{hwu2022pmpp,
+  author    = {Hwu, Wen-mei W. and Kirk, David B. and El Hajj, Izzat},
+  title     = {Programming Massively Parallel Processors: A Hands-on Approach},
+  edition   = {4},
+  publisher = {Morgan Kaufmann},
+  year      = {2022},
+  isbn      = {9780323912310}
+}
+
 @misc{nvidia-scada-fms2025,
   title        = {Advancing Memory and Storage Architectures for Next-Gen {AI} Workloads},
   author       = {Vikram Sharma Mailthody},


### PR DESCRIPTION
  Expands the background section with GPU/CUDA concepts needed to reason
  about device-initiated I/O, and improves consistency across the document.

  - Define peer-to-peer PCIe early in the PCIe section and use the term
    consistently throughout
  - Add a full CUDA section covering thread hierarchy, synchronization,
    streams, memory hierarchy, APIs, UVA, compute capability, and GPUDirect
  - Add a device-initiated I/O subsection under Massively Parallel Processing
    Units describing the PCIe mechanics of accelerator-driven storage access
  - Clean up the NVMe Controllers section opening
  - Add cross-references from introduction and architecture to the new
    background definitions