### PR TITLE
docs: add Experimental Framework section and expand environment descriptions

### DIFF
--- a/configs/aisio.toml
+++ b/configs/aisio.toml
@@ -18,8 +18,8 @@ tag = "v0.2.0"
 path = "/root/git/sil"
 
 [spdk.repository]
-remote = "https://github.com/ankit-sam/spdk.git"
-branch = "xnvme_bam"
+remote = "https://github.com/spdk/spdk"
+tag = "26.01"
 path = "/root/git/spdk"
 
 [fio.repository]

--- a/configs/nvstack.toml
+++ b/configs/nvstack.toml
@@ -1,5 +1,9 @@
 [nvidia.ofed]
+version = "24.10-3.2.5.0"
 url = "https://content.mellanox.com/ofed/MLNX_OFED-24.10-3.2.5.0/MLNX_OFED_LINUX-24.10-3.2.5.0-ubuntu24.04-x86_64.tgz"
+
+[nvidia.nokm]
+version = "570"
 
 [nvidia.gsp]
 url = "https://uk.download.nvidia.com/XFree86/Linux-x86_64/570.153.02/NVIDIA-Linux-x86_64-570.153.02.run"
@@ -10,7 +14,14 @@ remote = "https://github.com/NVIDIA/open-gpu-kernel-modules.git"
 tag = "570.153.02"
 
 [nvidia.cuda]
+apt_version = "12-8"
 url = "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run"
+
+[nvidia.cuda.samples]
+tag = "v12.8"
+
+[nvidia.gds.repository]
+tag = "v2.26.6"
 
 [nvidia.keyring]
 url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -1,7 +1,28 @@
 import os
 import sys
+import tomllib
+from pathlib import Path
 from datetime import datetime
 
+
+_repo_root = Path(__file__).resolve().parent.parent.parent
+
+with open(_repo_root / "configs/aisio.toml", "rb") as _f:
+    _aisio = tomllib.load(_f)
+
+with open(_repo_root / "configs/nvstack.toml", "rb") as _f:
+    _nvstack = tomllib.load(_f)
+
+myst_substitutions = {
+    "ver_xnvme":  _aisio["xnvme"]["repository"]["branch"],
+    "ver_spdk":   _aisio["spdk"]["repository"]["tag"],
+    "ver_xal":    _aisio["xal"]["repository"]["tag"],
+    "ver_sil":    _aisio["sil"]["repository"]["tag"],
+    "ver_fio":    _aisio["fio"]["repository"]["tag"].removeprefix("fio-"),
+    "ver_ofed":   _nvstack["nvidia"]["ofed"]["version"],
+    "ver_nokm":   _nvstack["nvidia"]["nokm"]["version"] + ".x",
+    "ver_cuda":   _nvstack["nvidia"]["cuda"]["apt_version"].replace("-", ".") + ".x",
+}
 
 project = "AiSIO"
 author = "Simon A. F. Lund, Karl Bonde Torp, Nadja Brix Koch, Javier González"

--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -17,15 +17,6 @@ The configurations reflect practical system builds intended to support
 architectural exploration, implementation, and comparative evaluation, rather
 than prescribing production deployment guidelines
 
-## System Setup and Benchmarks
-
-Brief introduction to CIJOE, configs / workflows / scripts.
-
-* OS Installation
-* NVIDIA Software Stack Setup
-* Dataset Populaton on NVMe
-* Running benchmarks
-
 ## V100 16GB
 
 1x Gigabyte ...

--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -3,8 +3,8 @@
 
 This section describes the system configurations used for experimenting
 with AiSIO system software architectures, including the initial AiSIO
-proof-of-concept and the development of the HOMI reference implementation. These
-environments support evaluation, document constraints encountered during HOMI
+proof-of-concept and the development of a reference implementation. These
+environments support evaluation, document constraints encountered during
 development, and serve as reproducible reference builds for readers wishing to
 explore similar architectures.
 
@@ -15,31 +15,69 @@ conditions.
 
 The configurations reflect practical system builds intended to support
 architectural exploration, implementation, and comparative evaluation, rather
-than prescribing production deployment guidelines
+than prescribing production deployment guidelines.
 
-## V100 16GB
+(sec-env-hpc-server)=
+## High-Performance Compute Server
 
-1x Gigabyte ...
-1x AMD EPYC
-2x V100 Discrete
-4x Samsung 980 PRO
+An enterprise-grade dual-socket server with high-capacity NVMe storage, used for the
+primary CPU-initiated I/O and benchmark tool comparison experiments. The platform,
+GPU, and NVMe storage all operate at PCIe Gen5, providing full-bandwidth connectivity
+throughout the system. With 32 × 64 GiB of DDR5, the system provides 2 TiB of host
+memory.
 
-## H100 80G
+| Hardware    | Details                            |
+| ----------- | ---------------------------------- |
+| Motherboard | Dell PowerEdge R760                |
+| CPU         | 2x Intel® Xeon® Gold 6442Y         |
+| Memory      | 32x 64GiB Samsung DDR5 4800MHz     |
+| GPU         | 2x NVIDIA H100 80GB                |
+| Storage     | 16x Samsung SSD PM1753 32TB        |
 
-| Hardware | Details                              |
-| -------- | ------------------------------------ |
-| CPU      | 2x Intel® Xeon® Gold 6442Y Processor |
-| GPU      | 2x NVIDIA H100 Discrete              |
-| Storage  | 16x Samsung SSD PM1753 32TB SSD      |
+(sec-env-gpu-workstation)=
+## Professional GPU Workstation
 
-## RTX A5000 24GB
+A workstation built around a professional-grade GPU with a high core-count CPU, used for
+development and evaluation of the reference implementation. The platform, GPU, and
+NVMe storage all operate at PCIe Gen4.
 
-1x AMD EPYC
-1x RTX A5000 24GB
-4x Samsung 990 PRO 2TB
+| Hardware    | Details                          |
+| ----------- | -------------------------------- |
+| Motherboard | Supermicro H12SSL-I                  |
+| CPU         | 1x AMD EPYC 7532 32-Core (Rome)      |
+| Memory      | 8x 32GiB Samsung DDR4 2667MHz        |
+| GPU         | 1x NVIDIA RTX A5000 24GB             |
+| Storage     | 4x Samsung 990 PRO 2TB               |
 
-## RTX A2000 6GB
+(sec-env-desktop)=
+## Desktop Workstation
 
-1x
-1x RTX A2000 6GB
-1x Samsung 980 PRO 1TB
+A consumer desktop used for development and light experimentation. Both the NVIDIA RTX
+A2000 6GB and the NVIDIA RTX PRO 2000 Blackwell 16GB have been used and validated in
+this environment. The AMD B550 platform limits PCIe bandwidth to Gen4 on CPU-direct
+slots, constraining the RTX PRO 2000 Blackwell below its Gen5 capability. A single NVMe
+device limits aggregate storage bandwidth and precludes multi-device parallelism.
+
+| Hardware    | Details                                                    |
+| ----------- | ---------------------------------------------------------- |
+| Motherboard | MSI MAG B550M MORTAR WIFI                                  |
+| CPU         | 1x AMD Ryzen 7 5800X 8-Core                                |
+| Memory      | 2x 16GiB DDR4 2133MHz                                      |
+| GPU         | 1x NVIDIA RTX PRO 2000 Blackwell 16GB / RTX A2000 6GB      |
+| Storage     | 1x Samsung 980 PRO 1TB                                     |
+
+(sec-env-legacy)=
+## Legacy GPU Server
+
+A server based on legacy Volta-generation GPUs, used for the initial AiSIO
+proof-of-concept experiments. The V100 is a PCIe Gen3 device, limiting peak GPU bandwidth
+to approximately 16 GB/s per slot and constraining peer-to-peer DMA throughput compared
+to Gen4 systems.
+
+| Hardware    | Details                              |
+| ----------- | ------------------------------------ |
+| Motherboard | Gigabyte G292-Z20                  |
+| CPU         | 1x AMD EPYC 7402P 24-Core          |
+| Memory      | 8x 32GiB SK Hynix DDR4 2400MHz     |
+| GPU         | 2x NVIDIA V100 16GB                |
+| Storage     | 4x Samsung 980 PRO 1TB             |

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -1,0 +1,236 @@
+(sec-experimental-framework)=
+# Experimental Framework
+
+## System Setup
+
+All environment provisioning is automated using
+[CIJOE](https://github.com/refenv/cijoe), a tool for systems development
+and testing. CIJOE runs on a local initiator machine and connects to a
+remote target over SSH. Shell commands and Python scripts are collected
+into YAML workflow definitions that document the execution sequence and
+combined purpose. Input values are kept separate from scripts in TOML
+configuration files, so the same workflow can be replicated across
+different environments without modifying the scripts themselves. After
+execution, CIJOE generates a report covering command output, script
+documentation, collected artifacts, and a workflow summary.
+
+Step-by-step instructions for running the CIJOE setup tasks are provided
+in the ``README.md`` of the AiSIO repository. The table below lists all
+software components installed on each system, in installation order.
+
+| Category | Component                  | Version              | Install       | Description                                                                                                                         |
+| -------- | -------------------------- | -------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| OS       | Ubuntu Server              | 24.04.4              | ISO           | Base operating system; GA kernel required (HWE must be disabled)                                                                    |
+| Kernel   | Linux + udmabuf-import     | 6.8 GA + patch       | Source        | Ubuntu GA kernel patched to add DMA-buf importer support to UDMABUF, enabling physical address resolution of device memory from user space |
+| NVIDIA   | MLNX\_OFED                 | {{ ver_ofed }}       | Source        | Mellanox OFED with NVMe-oF, NFS-RDMA, and GPUDirect Storage support                                                                |
+| NVIDIA   | Open Kernel Modules        | {{ ver_nokm }}       | APT           | NVIDIA open-source GPU kernel driver                                                                                                |
+| NVIDIA   | CUDA Toolkit               | {{ ver_cuda }}       | APT           | CUDA compiler, runtime, and libraries                                                                                               |
+| NVIDIA   | nvidia-fs                  | {{ ver_cuda }}       | APT           | GPUDirect Storage kernel module                                                                                                     |
+| AiSIO    | fio                        | {{ ver_fio }}        | Source        | I/O benchmark tool; built from source for SPDK plugin integration                                                                   |
+| AiSIO    | SPDK                       | {{ ver_spdk }}       | Source        | Storage Performance Development Kit; provides the user space NVMe driver and bdevperf                                              |
+| AiSIO    | xNVMe                      | {{ ver_xnvme }}      | Source        | Unified NVMe command interface with uPCIe backend support                                                                           |
+| AiSIO    | xal                        | {{ ver_xal }}        | Source        | XFS Abstraction Library for file-to-block extent resolution                                                                         |
+| AiSIO    | sil                        | {{ ver_sil }}        | Source        | Storage I/O Library; benchmark harness used to evaluate different I/O backends                                                      |
+| Tools    | devbind                    | —                    | pipx          | NVMe PCIe driver binding utility                                                                                                    |
+| Tools    | hugepages                  | —                    | pipx          | Huge page allocation management utility                                                                                             |
+
+## Benchmarks
+
+The benchmarks fall into two groups: synthetic benchmarks that issue I/O
+directly against raw NVMe devices, and file-based benchmarks that load
+datasets from an XFS filesystem on a dedicated NVMe device.
+
+### Synthetic
+
+Synthetic benchmarks issue I/O directly to NVMe devices via user space
+drivers, bypassing the kernel filesystem stack. They require a device
+configuration file listing the NVMe block devices to use.
+``configs/devices_16.toml`` is provided as an example and must be edited
+to match the target system. Device PCI addresses can be found with:
+
+```
+lspci | grep Non-Volatile
+```
+
+If the boot device is an NVMe device, it must be excluded from driver
+rebinding by setting the ``xnvme.driver.prefix`` key in the
+configuration file:
+
+```toml
+[xnvme.driver]
+prefix = "PCI_BLACKLIST=0000:01:00.0"
+```
+
+Devices must be unbound from the kernel NVMe driver and bound to
+``uio_pci_generic``. Huge pages are also required, as both SPDK and
+xNVMe uPCIe rely on DMA-capable memory that must be physically
+contiguous and pinned:
+
+```
+devbind --device '<pci_addr>' --bind uio_pci_generic
+hugepages setup --count 1024
+```
+
+The benchmark workflows are parameterised by editing the ``run`` step in
+the respective task file. The keys under ``with`` correspond to
+independent variables. ``numcpus_range`` and ``numdevs_range`` are
+inclusive tuples defining the range of values tested, not complete
+lists. An optional ``results_dir`` key enables continuation of a
+previous run, and ``repetitions`` controls the number of runs per
+configuration (default: 5). When re-running benchmarks without changing
+system state, the hugepage allocation and driver binding steps can be
+skipped by specifying only the steps to execute:
+
+```
+cijoe \
+    -c configs/transport.toml \
+    -c configs/aisio.toml \
+    -c configs/devices_16.toml \
+    tasks/bench_io.yaml \
+    run combine visualize
+```
+
+Results are rendered as an interactive HTML page at
+``cijoe-output/artifacts/benchmark-results.html``, which allows results
+from different parameterisations to be compared.
+
+#### CPU-initiated I/O (``bench_io.yaml``)
+
+Characterises the maximum IOPS achievable through CPU-driven I/O using
+SPDK's bdevperf across a wide parameter space. Described in detail in
+{ref}`sec-experiments-cpu-initiated`.
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/aisio.toml \
+    -c configs/devices_16.toml \
+    tasks/bench_io.yaml
+```
+
+#### Benchmark Tool Comparison (``bench_tools.yaml``)
+
+Runs bdevperf, SPDK NVMe Perf, and xnvmeperf (with the spdk, upcie, and
+upcie-cuda backends) under identical parameters to isolate the effect of
+tool and driver implementation on measured IOPS. Described in detail in
+{ref}`sec-experiments-tool-comparison`.
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/aisio.toml \
+    -c configs/devices_16.toml \
+    tasks/bench_tools.yaml
+```
+
+### File-based
+
+File-based benchmarks load datasets from an XFS filesystem on a dedicated
+NVMe device. The device and mount point are specified in
+``configs/datasets.toml``. The following workflow formats the device, mounts it,
+and generates the synthetic datasets, and runs an XFS
+defragmentation pass to ensure contiguous file layout:
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/datasets.toml \
+    tasks/setup_dataset.yaml
+```
+
+Three datasets are generated, each modelling a different real-world
+workload in terms of file count and file size distribution:
+
+**imagenetish** models an image classification dataset. It consists of
+1000 classes with 1000 to 1400 files each (1.0–1.4 million files total),
+with individual file sizes between 75 KB and 150 KB.
+
+**tiktokish** models a short-form video library. It consists of 32 classes
+with 14 files each (448 files total), with individual file sizes between
+7 MiB and 8 MiB.
+
+**filesize8gib** models a large-file workload. It consists of 20 files,
+each exactly 8 GiB, used to evaluate performance with large individual
+files.
+
+All datasets are generated with a fixed random seed to ensure
+reproducibility across systems.
+
+The required driver binding depends on the benchmark: the AiSIO benchmark
+uses the xNVMe uPCIe path and requires the device bound to
+``uio_pci_generic`` with hugepages allocated:
+
+```
+umount /mnt/datasets
+devbind --device '<pci_addr>' --bind uio_pci_generic
+hugepages setup --count 1024
+```
+
+GDS, POSIX, and GDS transfer mode benchmarks operate through the kernel
+NVMe driver and require the device bound to ``nvme`` with the filesystem
+mounted:
+
+```
+devbind --device '<pci_addr>' --bind nvme
+mount /dev/<nvme_dev> /mnt/datasets
+```
+
+#### AiSIO / uPCIe (``bench_aisio.yaml``)
+
+This benchmark consists of two parts. First, the tiktokish and imagenetish
+datasets are loaded through SIL using the ``aisio-cpu`` backend, measuring
+end-to-end dataset loading performance over the AiSIO storage path. The
+``filesize8gib`` dataset is excluded because individual files exceed the
+256 MiB xNVMe uPCIe host-memory heap limit. Second, synthetic random-read
+benchmarks are run with xnvmeperf using the ``upcie`` (CPU completion) and
+``upcie-cuda`` (GPU completion) backends, measuring raw I/O throughput on
+the uPCIe path.
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/aisio.toml \
+    -c configs/datasets.toml \
+    tasks/bench_aisio.yaml
+```
+
+#### NVIDIA GPUDirect Storage (``bench_gds.yaml``)
+
+This benchmark evaluates NVIDIA GPUDirect Storage using the SIL
+interface. It loads all three datasets (imagenetish, tiktokish,
+filesize8gib) through the ``gds`` backend, and runs synthetic sequential
+and random-read benchmarks using gdsio.
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/datasets.toml \
+    tasks/bench_gds.yaml
+```
+
+#### POSIX (``bench_posix.yaml``)
+
+This benchmark provides a POSIX I/O baseline by loading all three
+datasets through the ``posix`` backend of SIL. It serves as a
+baseline comparison against the GDS and AiSIO paths.
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/datasets.toml \
+    tasks/bench_posix.yaml
+```
+
+#### GDS Transfer Mode Comparison (``compare_gds_xfermodes.yaml``)
+
+This workflow uses gdsio to evaluate different GDS transfer types for
+small 4 KiB I/O. The GDS API exposes multiple transfer modes (XferType)
+that differ in how data is moved between storage and GPU memory, and this
+benchmark identifies which is most suitable for small-I/O workloads.
+
+```
+cijoe --monitor \
+    -c configs/transport.toml \
+    -c configs/datasets.toml \
+    tasks/compare_gds_xfermodes.yaml
+```

--- a/docs/src/experiments.md
+++ b/docs/src/experiments.md
@@ -106,9 +106,9 @@ not, the first and last 10% of the reported cpu frequencies are discarded.
 
 ### Environment
 
-The benchmarks were run on the **H100 80G** machine described in the Environments
-section. All block devices were empty and bound to the uio-pci-generic user space
-driver. The CPU used the intel_cpufreq driver.
+The benchmarks were run on the {ref}`sec-env-hpc-server`. All block devices were
+empty and bound to the uio-pci-generic user space driver. The CPU used the
+intel_cpufreq driver.
 
 #### Empty vs. Populated Block Devices
 
@@ -247,11 +247,11 @@ placement on the data path, independent of the NVMe driver or benchmark tool.
 
 ### Experimental Setup
 
-The experiment uses the same hardware environment as the conventional
-CPU-initiated setup described in {ref}`sec-experiments`. All NVMe devices are
-bound to user space drivers. The CPU governor is set to ``performance`` with
-turbo boost and SMT enabled. Each benchmark configuration is run five times
-and results are reported as arithmetic means.
+The experiment was run on the {ref}`sec-env-hpc-server`, the same environment
+as the conventional CPU-initiated setup. All NVMe devices are bound to user space
+drivers. The CPU governor is set to ``performance`` with turbo boost and SMT
+enabled. Each benchmark configuration is run five times and results are reported
+as arithmetic means.
 
 The independent variables are:
 

--- a/docs/src/experiments.md
+++ b/docs/src/experiments.md
@@ -3,6 +3,7 @@
 
 (meta text)
 
+(sec-experiments-cpu-initiated)=
 ## Conventional CPU-initiated Setup
 
 In the first experimental setup, the I/O is CPU-driven and the host-memory is
@@ -142,85 +143,8 @@ how other processes in the system impact the achievable IOPS.
 
 ### Execution of the Experiment
 
-The execution of the experiment is automated by a cijoe workflow, which
-necessitates multiple cijoe configuration files. Most are given in this
-repository, but the ``configs/devices_16.toml`` configuration file is an example
-and must be edited to match the system you are running on.
-
-#### Configuration File
-
-A configuration file must contain the information about the following:
-
-1. Block devices
-1. A prefix for the ``xnvme-driver`` script
-
-This configuration file must define a list of NVMe block devices. To find
-these, run
-
-    lspci | grep Non-Volatile
-
-and change the `pci_addr` keys in the `[[devices]]` to match the PCI addresses of
-the found devices. There are 16 block devices in the example configuration file,
-but you can add more or remove devices as needed.
-
-The cijoe workflow assumes that if the boot device is an NVMe device, then the
-``xnvme.driver.prefix`` key has been defined in the configuration file to add the
-device's PCIe address to the PCI_BLACKLIST env variable for the xnvme-driver
-script. Example:
-
-    [xnvme.driver]
-    prefix = "PCI_BLACKLIST=0000:01:00.0"
-
-It's important that if the boot device is also an NVMe device that it is added in
-the ``PCI_BLACKLIST``, since the xnvme-driver script otherwise might unbind it,
-making the machine unusable (until next reboot).
-
-#### Setup of the Experiment
-
-The machine must be provisioned as described in the AiSIO repository README file,
-and the devices on the machine can be populated with the task defined in
-``tasks/populate_devices.yaml`. When the configuration file is created,
-it can be run with command
-
-    cijoe --monitor \
-      tasks/populate_devices.yaml \
-      -c configs/aisio.toml \
-      -c configs/devices_16.toml
-
-#### Running the Experiment
-
-When the system has been setup, the cijoe workflow must be configured with the
-right benchmarking parameters. In the file ``tasks/bench_io.yaml``, the
-step "run" has multiple keys under "with" which represent the independent
-variables of the experiment. The key ``results_dir`` is optional, but allows
-continuation of previously run benchmarks. Note that the ``numcpus_range`` and
-``numdevs_range`` are tuples describing the range of CPUs and block devices used
-for testing, both inclusive, meaning it is not a complete list of values for these
-independent variables. A key ``repetitions`` can be added to change the number of
-times each benchmark is run; if not defined, the default is 5 repetitions.
-
-When the "run" step has been parameterized, the workflow can be run with command
-
-    cijoe --monitor \
-      tasks/bench_io.yaml \
-      -c configs/aisio.toml \
-      -c configs/devices_16.toml
-
-This workflow makes sure to allocate hugepages and bind the block devices to
-user space drivers before running the benchmarks. This is not necessary to do
-repeatedly if running the benchmarks multiple times in a row. These steps can be
-skipped by specifying which steps to run in the command
-
-    cijoe \
-      tasks/bench_io.yaml \
-      -c configs/aisio.toml \
-      -c configs/devices_16.toml
-      run combine visualize
-
-In the final step, the results of the experiment is visualized on a graph in an
-interactive HTML page, which can be found in the cijoe artifacts found in
-``cijoe-output/artifacts/benchmark-results.html``. With this HTML page, the
-results of different parametirizations can be compared.
+Instructions for running ``bench_io.yaml`` are provided in
+{ref}`sec-experimental-framework`.
 
 (sec-experiments-tool-comparison)=
 ## Benchmark Tool Comparison

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,8 +9,9 @@ background
 architecture
 related
 implementation
-experiments
 environments
+experimental_framework
+experiments
 results
 future_work
 references

--- a/tasks/setup_nvstack.yaml
+++ b/tasks/setup_nvstack.yaml
@@ -66,13 +66,13 @@ steps:
 
 - name: gpu_driver
   run: |
-    apt-get install -y nvidia-driver-570-server-open
+    apt-get install -y nvidia-driver-{{ config.nvidia.nokm.version }}-server-open
 
 # Build NVIDIA kernel source tree to generate symbols/headers required by libnvm / BAM (not done
 # automatically by DKMS)
 - name: gpu_driver_kernel_source
   run: |
-    cd /usr/src/nvidia-*570*/ && make -j
+    cd /usr/src/nvidia-*{{ config.nvidia.nokm.version }}*/ && make -j
 
 - name: reboot_driver
   run: shutdown -r now
@@ -98,7 +98,7 @@ steps:
 
 - name: cuda
   run: |
-    apt-get install -y cuda-toolkit-12-8
+    apt-get install -y cuda-toolkit-{{ config.nvidia.cuda.apt_version }}
 
 # Setup CUDA for all interactive shells via '/etc/profile.d' and source this it explicitly for
 # 'root' via /root/.bashrc for non-interactive use of CUDA via e.g. ssh
@@ -119,12 +119,12 @@ steps:
 - name: cuda_samples
   run: |
     git clone https://github.com/NVIDIA/cuda-samples.git git/cuda-samples
-    cd git/cuda-samples; git checkout v12.8
+    cd git/cuda-samples; git checkout {{ config.nvidia.cuda.samples.tag }}
     mkdir git/cuda-samples/build
 
 - name: nvidia_gds
   run: |
-    apt-get install -y nvidia-gds-12-8
+    apt-get install -y nvidia-gds-{{ config.nvidia.cuda.apt_version }}
 
 - name: checkup
   run: |

--- a/tasks/setup_nvstack_from_source.yaml
+++ b/tasks/setup_nvstack_from_source.yaml
@@ -136,7 +136,7 @@ steps:
 - name: cuda_samples
   run: |
     git clone https://github.com/NVIDIA/cuda-samples.git git/cuda-samples
-    cd git/cuda-samples; git checkout v12.8
+    cd git/cuda-samples; git checkout {{ config.nvidia.cuda.samples.tag }}
     mkdir git/cuda-samples/build
 
 - name: cuda_check
@@ -147,8 +147,8 @@ steps:
 - name: gds
   run: |
     git clone https://github.com/NVIDIA/gds-nvidia-fs.git git/gds
-    cd git/gds; git checkout v2.26.6
-    cd git/gds/src; NVIDIA_SRC_DIR={{ config.nvidia.modules.repository.path }}/kernel-open/nvidia CONFIG_MOFED_VERSION="24.10" make
+    cd git/gds; git checkout {{ config.nvidia.gds.repository.tag }}
+    cd git/gds/src; NVIDIA_SRC_DIR={{ config.nvidia.modules.repository.path }}/kernel-open/nvidia CONFIG_MOFED_VERSION=$(echo "{{ config.nvidia.ofed.version }}" | cut -d- -f1) make
     cd git/gds/src; make install
     cd git/gds/src; insmod nvidia-fs.ko
     echo "nvidia-fs" | tee -a /etc/modules-load.d/nvidia.conf


### PR DESCRIPTION
- Adds a new Experimental Framework section covering system setup,
    software installation order, and benchmark workflows (synthetic and
    file-based), extracted from the Environments section where it did not
    belong
- Expands Environments with full hardware tables: descriptive system
    names, class descriptions, motherboard, CPU, memory, storage, and PCIe
    generation constraints for all four setups
- Centralises all NVIDIA software versions in nvstack.toml; install
    scripts (setup_nvstack.yaml, setup_nvstack_from_source.yaml) now
    reference config values instead of hardcoding versions, and the
    white-paper sources the same values dynamically via conf.py
- Updates SPDK to the official repository at tag 26.01