### PR TITLE
refactor: rename sil to fil across scripts, docs, configs, and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cijoe --monitor \
 
 ## Step 5: Set Up AiSIO Components
 
-Build and install the AiSIO software stack (xNVMe, SPDK, xal, sil):
+Build and install the AiSIO software stack (xNVMe, SPDK, xal, fil):
 
 ```
 cijoe --monitor \

--- a/configs/aisio.toml
+++ b/configs/aisio.toml
@@ -12,10 +12,10 @@ remote = "https://github.com/xnvme/xal"
 tag = "v0.2.0"
 path = "/root/git/xal"
 
-[sil.repository]
-remote = "https://github.com/karlowich/sil"
-tag = "v0.2.0"
-path = "/root/git/sil"
+[fil.repository]
+remote = "https://github.com/xnvme/fil"
+tag = "v0.2.1"
+path = "/root/git/fil"
 
 [spdk.repository]
 remote = "https://github.com/spdk/spdk"

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -17,7 +17,7 @@ myst_substitutions = {
     "ver_xnvme":  _aisio["xnvme"]["repository"]["branch"],
     "ver_spdk":   _aisio["spdk"]["repository"]["tag"],
     "ver_xal":    _aisio["xal"]["repository"]["tag"],
-    "ver_sil":    _aisio["sil"]["repository"]["tag"],
+    "ver_fil":    _aisio["fil"]["repository"]["tag"],
     "ver_fio":    _aisio["fio"]["repository"]["tag"].removeprefix("fio-"),
     "ver_ofed":   _nvstack["nvidia"]["ofed"]["version"],
     "ver_nokm":   _nvstack["nvidia"]["nokm"]["version"] + ".x",

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -30,7 +30,7 @@ software components installed on each system, in installation order.
 | AiSIO    | SPDK                       | {{ ver_spdk }}       | Source        | Storage Performance Development Kit; provides the user space NVMe driver and bdevperf                                              |
 | AiSIO    | xNVMe                      | {{ ver_xnvme }}      | Source        | Unified NVMe command interface with uPCIe backend support                                                                           |
 | AiSIO    | xal                        | {{ ver_xal }}        | Source        | XFS Abstraction Library for file-to-block extent resolution                                                                         |
-| AiSIO    | sil                        | {{ ver_sil }}        | Source        | Storage I/O Library; benchmark harness used to evaluate different I/O backends                                                      |
+| AiSIO    | fil                        | {{ ver_fil }}        | Source        | File Iterator Library; benchmark harness used to evaluate different I/O backends                                                    |
 | Tools    | devbind                    | —                    | pipx          | NVMe PCIe driver binding utility                                                                                                    |
 | Tools    | hugepages                  | —                    | pipx          | Huge page allocation management utility                                                                                             |
 
@@ -178,7 +178,7 @@ mount /dev/<nvme_dev> /mnt/datasets
 #### AiSIO / uPCIe (``bench_aisio.yaml``)
 
 This benchmark consists of two parts. First, the tiktokish and imagenetish
-datasets are loaded through SIL using the ``aisio-cpu`` backend, measuring
+datasets are loaded through FIL using the ``aisio-cpu`` backend, measuring
 end-to-end dataset loading performance over the AiSIO storage path. The
 ``filesize8gib`` dataset is excluded because individual files exceed the
 256 MiB xNVMe uPCIe host-memory heap limit. Second, synthetic random-read
@@ -196,7 +196,7 @@ cijoe --monitor \
 
 #### NVIDIA GPUDirect Storage (``bench_gds.yaml``)
 
-This benchmark evaluates NVIDIA GPUDirect Storage using the SIL
+This benchmark evaluates NVIDIA GPUDirect Storage using the FIL
 interface. It loads all three datasets (imagenetish, tiktokish,
 filesize8gib) through the ``gds`` backend, and runs synthetic sequential
 and random-read benchmarks using gdsio.
@@ -211,7 +211,7 @@ cijoe --monitor \
 #### POSIX (``bench_posix.yaml``)
 
 This benchmark provides a POSIX I/O baseline by loading all three
-datasets through the ``posix`` backend of SIL. It serves as a
+datasets through the ``posix`` backend of FIL. It serves as a
 baseline comparison against the GDS and AiSIO paths.
 
 ```

--- a/docs/src/implementation.md
+++ b/docs/src/implementation.md
@@ -31,9 +31,9 @@ The **AiSIO** PoC demonstrates functionality on Linux systems using:
 - The NVIDIA GPU driver and its peer-to-peer memory interface for direct DMA
   between the NVMe controller and GPU device memory.
 - The XAL metadata decoder for XFS.
-- The Storage Iterator Library (SIL), a benchmark application that iterates
-  over file-based datasets using xal for extent resolution and exercises both
-  CPU and GPU I/O paths.
+- The SIL: Storage Iterator Library (now called FIL: File Iterator Library),
+  a benchmark application that iterates over file-based datasets using XAL
+  for extent resolution and exercises both CPU and GPU I/O paths.
 
 The PoC is open-source, reproducible, and interoperates with unmodified XFS.
 

--- a/scripts/filperf.py
+++ b/scripts/filperf.py
@@ -1,5 +1,5 @@
 """
-A SIL-wrapper invoking it with arguments
+A FIL-wrapper invoking it with arguments
 ========================================
 
 Retargetable: True
@@ -17,14 +17,11 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--backend", type=str, default="posix")
     parser.add_argument("--dataset", type=str, default="imagenetish")
     parser.add_argument("--device", type=str, default="/dev/nvme1n1")
-    parser.add_argument("--bin", type=str, default="sil")
+    parser.add_argument("--bin", type=str, default="filperf")
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--batches", type=int, default=1)
     parser.add_argument("--gpu_nqueues", type=int, default=6)
     parser.add_argument("--repetitions", type=int, default=5)
-    parser.add_argument(
-        "--random", choices=["true", "false"], default=False, action=StringToBoolAction
-    )
 
 
 def get_opts(args, cijoe, backend):

--- a/tasks/bench_aisio.yaml
+++ b/tasks/bench_aisio.yaml
@@ -1,8 +1,8 @@
 doc: |
-  Run SIL benchmarks to evaluate AiSIO performance
-  ================================================
+  Run benchmarks to evaluate AiSIO performance
+  ============================================
 
-  The benchmark includes:
+  The benchmarks include:
   - reading 2 datasets: tiktokish, imagenetish (filesize8gib is skipped as
     individual files exceed the 256MB xNVMe uPCIe HOSTMEM heap limit),
   - performing synthetic randread benchmarks for: upcie, upcie-cuda
@@ -14,7 +14,7 @@ doc: |
 
 steps:
 - name: tiktokish
-  uses: sil
+  uses: filperf
   with:
     backend: "aisio-cpu"
     dataset: "tiktokish"
@@ -24,7 +24,7 @@ steps:
     repetitions: 1
 
 - name: imagenetish
-  uses: sil
+  uses: filperf
   with:
     backend: "aisio-cpu"
     dataset: "imagenetish"


### PR DESCRIPTION
- Rename scripts/sil.py to scripts/filperf.py; update default --bin to filperf and remove --random argument
- Update configs/aisio.toml: rename [sil] to [fil], point remote to xnvme/fil, update path to /root/git/fil, bump tag to v0.2.1
- Update tasks/bench_aisio.yaml: replace uses: sil with uses: filperf
- Update docs: replace SIL/sil with FIL/fil throughout experimental_framework.md, implementation.md, and conf.py (ver_sil -> ver_fil substitution key)
- Update README.md: fix sil -> fil in component list