### PR TITLE
feat(bench): add PCIe bandwidth benchmark with GPU monitoring

### DIFF
--- a/configs/nvstack.toml
+++ b/configs/nvstack.toml
@@ -18,7 +18,9 @@ apt_version = "12-8"
 url = "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run"
 
 [nvidia.cuda.samples]
+remote = "https://github.com/NVIDIA/cuda-samples"
 tag = "v12.8"
+path = "/root/git/cuda-samples"
 
 [nvidia.gds.repository]
 tag = "v2.26.6"

--- a/scripts/bench_combine.py
+++ b/scripts/bench_combine.py
@@ -56,7 +56,7 @@ def main(args, cijoe: Cijoe):
                 repeated_results.append(json_load(file))
 
         # err, result = get_average(repeated_results)
-        err, result = merge_dicts(repeated_results, ["cpu_freqs", "iops", "mibs", "cpu_usage"])
+        err, result = merge_dicts(repeated_results, ["cpu_freqs", "iops", "mibs", "cpu_usage", "dcgm"])
         if err:
             log.error("Failed: merge_dicts()")
             return err
@@ -68,6 +68,7 @@ def main(args, cijoe: Cijoe):
         result["iops"] = avg_stddev(result["iops"])
         result["mibs"] = avg_stddev(result["mibs"])
         result["cpu_usage"] = avg_stddev(result["cpu_usage"])
+        result["dcgm"] = avg_stddev(result["dcgm"]) if "dcgm" in result else 0
 
         all_results[label].append(result)
 
@@ -79,6 +80,10 @@ def main(args, cijoe: Cijoe):
 
 def avg_stddev(ns: List[Union[int, float]]):
     """Calculate the average and standard deviation of a list"""
+    if not ns[0]:
+        # safeguard against [None, None, None, None, None]
+        return 0
+
     avg = sum(ns) / len(ns)
     stddev = (sum((x - avg) ** 2 for x in ns) / len(ns)) ** 0.5
     return avg, stddev

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -31,6 +31,7 @@ import json
 import logging as log
 
 from bdevperf import bdevperf_cmd, create_config as bdevperf_config
+from dcgm_helper import DcgmHelper
 from spdk_nvme_perf import spdk_nvme_perf_cmd
 from xnvmeperf import xnvmeperf_cmd
 
@@ -54,6 +55,8 @@ class BenchHelper():
         self.stress = False
         self.backend = backend
         self.tool = tool
+
+        self.dcgm = DcgmHelper(cijoe) if backend == "upcie-cuda" else None
 
         self.use_thrsib = False
         err = self._create_cpumasks(self.use_thrsib)
@@ -163,33 +166,56 @@ class BenchHelper():
                 "wait $STRESS_PID",
             ])
 
+        def abort_monitors():
+            self.cfm.stop_logging_and_parse()
+            if self.dcgm:
+                self.dcgm.stop_and_parse()
+
         self.cfm.set_cpu_freq(cpu_freq, selected_cpus)
         err = self.cfm.start_logging()
         if err:
             log.error("Failed: CpuFrequencyHelper.start_logging()")
             return err, None
 
+        if self.dcgm:
+            err = self.dcgm.start()
+            if err:
+                self.cfm.stop_logging_and_parse()
+                log.error("Failed: DcgmHelper.start()")
+                return err, None
+
         err, state = self.cijoe.run(command)
         if err:
+            abort_monitors()
             log.error(f"Failed: {self.bin} for run with filename({filename})")
             return err, None
 
         output = state.output()
         err, cpu_usage = self._parse_time_output(output)
         if err:
+            abort_monitors()
             log.error("Failed: BenchHelper._parse_time_output()")
             return err, None
 
         err, bench_result = self._parse_bench_results(output)
         if err:
+            abort_monitors()
             log.error("Failed: BenchHelper._parse_bench_results()")
             return err, None
 
-
         err, cpu_freqs = self.cfm.stop_logging_and_parse()
         if err:
+            if self.dcgm:
+                self.dcgm.stop_and_parse()
             log.error("Failed: CpuFrequencyHelper.stop_logging_and_parse()")
             return err, None
+
+        dcgm_stats = None
+        if self.dcgm:
+            err, dcgm_stats = self.dcgm.stop_and_parse()
+            if err:
+                log.error("Failed: DcgmHelper.stop_and_parse()")
+                return err, None
 
         cpu_freqs = [[cpu_freqs[idx], self.cpu_pairs[idx]] for idx in selected_cpus]
 
@@ -210,6 +236,7 @@ class BenchHelper():
             "backend": self.backend,
             "iops": bench_result["total"]["iops"],
             "mibs": bench_result["total"]["mibs"],
+            "dcgm": dcgm_stats["1010"]["p95"] if self.dcgm else None,
         }
 
         with open(res_path, "x") as file:

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -151,7 +151,7 @@ class BenchHelper():
 
         else:
             log.error(f"Unknown tool: {self.tool}")
-            return -1
+            return -1, None
 
         selected_cpus = [v[0] for v in self.cpu_pairs if int(bench_args["cpumask"], 16) & (1 << v[0])]
 

--- a/scripts/bench_visualize.py
+++ b/scripts/bench_visualize.py
@@ -37,6 +37,13 @@ def main(args, cijoe):
 
     datasets = convert_to_data(results)
 
+    cuda_bandwidth = ""
+    bandwidth_path = artifacts / "cuda-sample-p2p-bandwidth"
+
+    if args.template == "benchmark-pcie" and bandwidth_path.exists():
+        with open(artifacts / "cuda-sample-p2p-bandwidth", "r") as file:
+            cuda_bandwidth = file.read()
+
     template_resource = get_resources().get("templates", {}).get(args.template, {})
     if not template_resource:
         log.error(f"Failed: could not find template resource({args.template})")
@@ -49,7 +56,7 @@ def main(args, cijoe):
 
     template = template_env.get_template(f"{args.template}.jinja2")
     with html_path.open("w") as body:
-        body.write(template.render({ "datasets": datasets }))
+        body.write(template.render({ "datasets": datasets, "cuda_bandwidth": cuda_bandwidth }))
 
     return 0
 

--- a/scripts/cuda_p2p_sample.py
+++ b/scripts/cuda_p2p_sample.py
@@ -1,0 +1,47 @@
+"""
+Run I/O benchmarks
+==================
+
+Run many benchmarks using SPDK's I/O benchmarking tool, bdevperf.
+
+Retargetable: True
+------------------
+"""
+
+from pathlib import Path
+from re import search
+import logging as log
+
+from cijoe.core.command import Cijoe
+
+
+def main(args, cijoe: Cijoe):
+  """Run cuda sample p2platency"""
+
+  artifacts = Path(args.output) / "artifacts"
+
+  sample_path = cijoe.getconf("nvidia.cuda.samples.path", None)
+  if not sample_path:
+    log.error("Failed: Missing path to cuda-samples")
+    return -1
+
+  bin = Path(sample_path) / "build" / "Samples" / "5_Domain_Specific" / "p2pBandwidthLatencyTest" / "p2pBandwidthLatencyTest"
+
+  err, state = cijoe.run(f"{bin}")
+  if err:
+    log.error(f"Failed: run(p2pBandwidthLatencyTest); err({err})")
+    return err
+
+  regex = r"Bidirectional P2P=Enabled Bandwidth.*\n.*\n\s*\d+\s+([0-9.]+)\s+(?P<bw1>[0-9.]+).*\n\s*\d+\s+(?P<bw2>[0-9.]+)\s+([0-9.]+).*\n"
+  m = search(regex, state.output())
+  if not m:
+    log.error("Failed: unexpected output from p2pBandwidthLatencyTest")
+    return -1
+
+  bandwidths = [float(v) for v in m.groupdict().values()]
+  bandwidth = sum(bandwidths) / 2 #in GB/s
+
+  with open(artifacts / "cuda-sample-p2p-bandwidth", "x") as out:
+    out.write(f"{bandwidth}")
+
+  return 0

--- a/scripts/dcgm_helper.py
+++ b/scripts/dcgm_helper.py
@@ -1,0 +1,93 @@
+from cijoe.core.command import Cijoe
+from pathlib import Path
+from statistics import mean, quantiles
+from typing import Dict, List, Optional, Tuple
+import logging as log
+
+
+class DcgmHelper:
+    """
+    Start and stop dcgmi dmon monitoring and parse the collected samples.
+
+    Requires dcgmi and screen to be available on the target system. Fields
+    are DCGM profiling field IDs passed to ``dcgmi dmon -e``. The defaults
+    (1009, 1010) correspond to PCIe TX and RX bytes per second, which is the
+    primary metric of interest for P2P transfers in the upcie-cuda path.
+
+    Configure via cijoe config:
+
+        [dcgm]
+        fields = ["1009", "1010"]
+        gpu = 0
+    """
+
+    def __init__(self, cijoe: Cijoe, gpu: Optional[int] = None, fields: Optional[List[str]] = None):
+        self.cijoe = cijoe
+        self.gpu = gpu if gpu is not None else cijoe.getconf("dcgm.gpu", 0)
+        self.fields = fields if fields is not None else cijoe.getconf("dcgm.fields", ["1009", "1010"])
+        self._output = Path("/tmp/dcgm_monitor.txt")
+        self._is_running = False
+
+    def start(self) -> int:
+        """
+        Start dcgmi dmon in the background via screen.
+
+        Returns 0 on success, non-zero on failure.
+        """
+        if self._is_running:
+            return 0
+
+        self.cijoe.run(f"rm -f {self._output}")
+
+        fields_arg = ",".join(self.fields)
+        cmd = f'screen -dm bash -c "dcgmi dmon -d 100 -i {self.gpu} -e {fields_arg} > {self._output}"'
+        err, _ = self.cijoe.run(cmd)
+        if err:
+            log.error("Failed: dcgmi dmon")
+            return err
+
+        self._is_running = True
+        return 0
+
+    def stop_and_parse(self) -> Tuple[int, Dict[str, dict]]:
+        """
+        Stop monitoring and parse collected samples.
+
+        Returns ``(err, stats)`` where ``stats`` maps each field ID to a dict
+        with keys ``samples``, ``mean``, and ``p95``. Values are in the native
+        unit reported by dcgmi dmon (bytes/sec for PCIe fields).
+        """
+        self.cijoe.run("pkill -f dcgmi; sleep 0.2")
+        self._is_running = False
+
+        err, state = self.cijoe.run(f"cat {self._output}")
+        if err:
+            log.error(f"Failed: cat {self._output}")
+            return 1, None
+
+        raw: Dict[str, List[float]] = {f: [] for f in self.fields}
+        for line in state.output().splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("GPU"):
+                continue
+            # dmon line format: "GPU <id>   <val1>   <val2>   ..."
+            parts = stripped.removeprefix(f"GPU {self.gpu}").split()
+            for i, field in enumerate(self.fields):
+                if i < len(parts):
+                    try:
+                        raw[field].append(float(parts[i]))
+                    except ValueError:
+                        pass  # skip N/A entries
+
+        stats = {}
+        for field, values in raw.items():
+            if not values:
+                stats[field] = {"samples": [], "mean": None, "p95": None}
+                continue
+            stats[field] = {
+                "samples": values,
+                "mean": mean(values),
+                "p95": quantiles(sorted(values), n=100, method="inclusive")[94],
+            }
+
+        return 0, stats

--- a/tasks/bench_pcie.yaml
+++ b/tasks/bench_pcie.yaml
@@ -1,0 +1,76 @@
+doc: |
+  Run I/O benchmarks
+  ==================
+
+  Configuration file
+  ------------------
+  See `configs/devices_16.toml` for an example configuration file.
+
+  The configuration file must also define a list of NVMe block devices. To find these,
+  run
+
+    `lspci | grep Non-Volatile`
+
+  and change the `pci_addr` keys in the `[[devices]]` to match the PCI addresses of the
+  found devices.
+
+  If the boot device is an NVMe device, see "Binding to userspace" below.
+
+  Allocating hugepages
+  --------------------
+  It is not necessary to run this step if the workflow is run repeatedly.
+
+  Binding to userspace
+  --------------------
+  This scripts assumes if the boot device is an NVMe device, then the `xnvme.driver.prefix`
+  variable has been defined to add the device's PCIe address to the PCI_BLACKLIST env var
+  for the xnvme-driver script. Example:
+
+    [xnvme.driver]
+    prefix = "PCI_BLACKLIST=0000:01:00.0"
+
+  It's important that if the boot device is also an NVMe device that it's added in the
+  `PCI_BLACKLIST` in step "bind_to_userspace", since the xnvme-driver script otherwise
+  will unbind it, making the machine unusable (until next reboot).
+
+  It is not necessary to run this step if the workflow is run repeatedly.
+
+steps:
+- name: allocate_hugepages
+  run: |
+    sysctl -w vm.nr_hugepages=1024
+    mkdir -p /dev/hugepages
+    mountpoint -q /dev/hugepages || mount -t hugetlbfs nodev /dev/hugepages
+
+- name: bind_to_userspace
+  run: |
+    {{ config.xnvme.driver.prefix }} xnvme-driver
+
+- name: run
+  uses: bench_runall
+  with:
+    depths: [128]
+    sizes: [512, 4096, 8192]
+    numcpus_specific: [1]
+    numdevs_specific: [16]
+    cpu_freqs: ["performance"]
+    turbo: [1]
+    smt: [1]
+    hyperthreads: [0]
+    stress: [0]
+    results_dir: &results-dir "{{ local.env.HOME }}/bench-pcie-results"
+    tool: xnvmeperf
+    backend: upcie-cuda
+
+- name: cuda_bandwidth
+  uses: cuda_p2p_sample
+
+- name: combine
+  uses: bench_combine
+  with:
+    results_dir: *results-dir
+
+- name: visualize
+  uses: bench_visualize
+  with:
+    template: benchmark-pcie

--- a/tasks/setup_nvstack_from_source.yaml
+++ b/tasks/setup_nvstack_from_source.yaml
@@ -135,9 +135,11 @@ steps:
 
 - name: cuda_samples
   run: |
-    git clone https://github.com/NVIDIA/cuda-samples.git git/cuda-samples
-    cd git/cuda-samples; git checkout {{ config.nvidia.cuda.samples.tag }}
-    mkdir git/cuda-samples/build
+    git clone {{ config.nvidia.cuda.samples.remote }} {{ config.nvidia.cuda.samples.path }}
+    cd {{ config.nvidia.cuda.samples.path }}; git checkout {{ config.nvidia.cuda.samples.tag }}
+    mkdir {{ config.nvidia.cuda.samples.path }}/build
+    cd {{ config.nvidia.cuda.samples.path }}/build; cmake ..
+    cd {{ config.nvidia.cuda.samples.path }}/build; make -j $(nproc)
 
 - name: cuda_check
   run: |

--- a/templates/bench-dom.jinja2.html
+++ b/templates/bench-dom.jinja2.html
@@ -5,15 +5,15 @@
   <script>
     function disableInvalidRadios (element) {
       if (element.getAttribute("name") !== "smt") return;
-      const htRadio2 = document.querySelector(`#htRadios input[value="2"]`);
+      const htRadioOn = document.querySelector(`#htRadios input[value="1"]`);
       if (element.getAttribute("value") === "0") {
-        if (htRadio2.checked) {
-          const htRadio1 = document.querySelector(`#htRadios input[value="1"]`);
-          htRadio1.click();
+        if (htRadioOn.checked) {
+          const htRadioBoth = document.querySelector(`#htRadios input[value="undefined"]`);
+          htRadioBoth.click();
         }
-        htRadio2.disabled = true;
+        htRadioOn.disabled = true;
       } else {
-        htRadio2.disabled = false;
+        htRadioOn.disabled = false;
       }
     }
   </script>

--- a/templates/bench-update-chart.jinja2.js
+++ b/templates/bench-update-chart.jinja2.js
@@ -142,142 +142,6 @@ function updateChart() {
         ...datasets,
       ]
     },
-    plugins: [{
-      id: "shadingArea",
-      beforeDatasetsDraw(chart) {
-        if (BAR_TYPE !== 'line') return;
-
-        const { ctx, scales: { y } } = chart;
-
-        const tickHeight = y.height / y.max;
-        let count = chart.data.datasets.length;
-        if (y_axis.key === "iops") count--;
-
-        for (var i = 0; i < count; i++) {
-          const dataset = chart.data.datasets[i];
-          const dataset_meta = chart.getDatasetMeta(i);
-          if (!dataset_meta.data?.length || dataset_meta.hidden) continue;
-
-          ctx.save();
-
-          ctx.beginPath();
-          ctx.fillStyle = dataset.backgroundColor;
-          ctx.strokeStyle = dataset.backgroundColor;
-          ctx.globalAlpha = 0.2;
-
-          ctx.moveTo(dataset_meta.data[0].x, dataset_meta.data[0].y - tickHeight * dataset.data[0].v);
-
-          for (var j = 0; j < dataset.data.length; j++) {
-            ctx.lineTo(dataset_meta.data[j].x, dataset_meta.data[j].y - tickHeight * dataset.data[j].v);
-          }
-          for (var j = dataset.data.length-1; j >= 0; j--) {
-            ctx.lineTo(dataset_meta.data[j].x, dataset_meta.data[j].y + tickHeight * dataset.data[j].v);
-          }
-          ctx.fill();
-          ctx.globalAlpha = 1;
-        }
-      }
-    },{
-      id: "errorBars",
-      afterDatasetsDraw(chart) {
-        if (BAR_TYPE !== 'bar') return;
-
-        const { ctx, scales: { y } } = chart;
-        let count = chart.data.datasets.length;
-
-        for (var i = 0; i < count; i++) {
-          const dataset = chart.data.datasets[i];
-          const dataset_meta = chart.getDatasetMeta(i);
-          if (!dataset_meta.data?.length || dataset_meta.hidden) continue;
-
-          ctx.save();
-          ctx.strokeStyle = "black";
-          ctx.lineWidth = 1.5;
-
-          for (var j = 0; j < dataset.data.length; j++) {
-            const d = dataset.data[j];
-            const bar = dataset_meta.data[j];
-            const capHalf = Math.min(bar.width / 4, 6);
-            const yTop = y.getPixelForValue(d.y + d.v);
-            const yBottom = y.getPixelForValue(Math.max(0, d.y - d.v));
-
-            ctx.beginPath();
-            ctx.moveTo(bar.x, yTop);
-            ctx.lineTo(bar.x, yBottom);
-            ctx.moveTo(bar.x - capHalf, yTop);
-            ctx.lineTo(bar.x + capHalf, yTop);
-            ctx.moveTo(bar.x - capHalf, yBottom);
-            ctx.lineTo(bar.x + capHalf, yBottom);
-            ctx.stroke();
-          }
-
-          ctx.restore();
-        }
-      }
-    },{
-      id: "showMax",
-      afterDatasetsDraw(chart) {
-        const { ctx } = chart;
-        const drawn_labels = [];
-
-        if (BAR_TYPE === "bar" || document.getElementById("show-max-value").checked) {
-          let count = chart.data.datasets.length;
-          if (BAR_TYPE === "line" && y_axis.key === "iops") count--;
-
-          for (var i = 0; i < count; i++) {
-            const dataset = chart.data.datasets[i];
-            const dataset_meta = chart.getDatasetMeta(i);
-            if (!dataset_meta.data?.length || dataset_meta.hidden) continue;
-
-            ctx.save();
-            ctx.fillStyle = dataset.backgroundColor;
-            ctx.strokeStyle = dataset.backgroundColor;
-
-            if (BAR_TYPE === "bar") {
-              ctx.textAlign = "left";
-              for (var j = 0; j < dataset.data.length; j++) {
-                const bar = dataset_meta.data[j];
-                const text = separatedNumber(dataset.data[j].y);
-                ctx.save();
-                ctx.translate(bar.x, bar.y - 10);
-                ctx.rotate(-Math.PI / 2);
-                ctx.fillStyle = "black";
-                ctx.fillText(text, 0, 0);
-                ctx.restore();
-              }
-            } else {
-              const lastPoint = dataset.data[dataset.data.length-1];
-              const lastPointMeta = dataset_meta.data[dataset.data.length-1];
-              const text = separatedNumber(lastPoint.y);
-
-              const coord = { x: lastPointMeta.x + 10, y: lastPointMeta.y-6, w: ctx.measureText(text).width, h: 10 };
-
-              let goUp = coord.y;
-              let goDown = coord.y;
-
-              while (drawn_labels.some(r =>
-                goDown < r.y + r.h &&
-                goDown + coord.h > r.y
-              )) {
-                goDown += 4;
-              }
-              while (drawn_labels.some(r =>
-                goUp < r.y + r.h &&
-                goUp + coord.h > r.y
-              )) {
-                goUp -= 4;
-              }
-
-              if (coord.y-goUp < goDown-coord.y) coord.y = goUp;
-              else coord.y = goDown;
-
-              ctx.fillText(text, coord.x, coord.y+6);
-              drawn_labels.push({ ...coord, y: coord.y });
-            }
-          }
-        }
-      }
-    }],
     options: {
       animation: false,
       responsive: true,
@@ -341,12 +205,14 @@ function updateChart() {
               return (chartData.datasets[legendItem.datasetIndex].label);
             }
           }
-        }
+        },
+        errorBars: BAR_TYPE === 'bar',
+        shadingArea: BAR_TYPE === 'line',
+        showMax: BAR_TYPE === "bar" || document.getElementById("show-max-value").checked,
       },
     }
   });
 }
-updateChart();
 
 function updateFreqChart(datapoint) {
   const datasets = [];
@@ -417,7 +283,7 @@ function updateFreqChart(datapoint) {
               return (chartData.datasets[legendItem.datasetIndex].label);
             }
           }
-        }
+        },
       }
     }
   });
@@ -439,3 +305,138 @@ document.querySelectorAll(".controls .button-row.y button").forEach(button => {
     updateChart();
   })
 });
+
+/**
+ * Chart plugins
+ */
+Chart.register({
+  id: "shadingArea",
+  beforeDatasetsDraw(chart) {
+    const { ctx, scales: { y } } = chart;
+
+    const tickHeight = y.height / y.max;
+    let count = chart.data.datasets.length;
+    if (yValues[CUR_Y_AXIS].key === "iops") count--;
+
+    for (var i = 0; i < count; i++) {
+      const dataset = chart.data.datasets[i];
+      const dataset_meta = chart.getDatasetMeta(i);
+      if (!dataset_meta.data?.length || dataset_meta.hidden) continue;
+
+      ctx.save();
+
+      ctx.beginPath();
+      ctx.fillStyle = dataset.backgroundColor;
+      ctx.strokeStyle = dataset.backgroundColor;
+      ctx.globalAlpha = 0.2;
+
+      ctx.moveTo(dataset_meta.data[0].x, dataset_meta.data[0].y - tickHeight * dataset.data[0].v);
+
+      for (var j = 0; j < dataset.data.length; j++) {
+        ctx.lineTo(dataset_meta.data[j].x, dataset_meta.data[j].y - tickHeight * dataset.data[j].v);
+      }
+      for (var j = dataset.data.length-1; j >= 0; j--) {
+        ctx.lineTo(dataset_meta.data[j].x, dataset_meta.data[j].y + tickHeight * dataset.data[j].v);
+      }
+      ctx.fill();
+      ctx.globalAlpha = 1;
+    }
+  }
+},{
+  id: "errorBars",
+  afterDatasetsDraw(chart) {
+    const { ctx, scales: { y } } = chart;
+    let count = chart.data.datasets.length;
+
+    for (var i = 0; i < count; i++) {
+      const dataset = chart.data.datasets[i];
+      const dataset_meta = chart.getDatasetMeta(i);
+      if (!dataset_meta.data?.length || dataset_meta.hidden) continue;
+
+      ctx.save();
+      ctx.strokeStyle = "black";
+      ctx.lineWidth = 1.5;
+
+      for (var j = 0; j < dataset.data.length; j++) {
+        const d = dataset.data[j];
+        const bar = dataset_meta.data[j];
+        const capHalf = Math.min(bar.width / 4, 6);
+        const yTop = y.getPixelForValue(d.y + d.v);
+        const yBottom = y.getPixelForValue(Math.max(0, d.y - d.v));
+
+        ctx.beginPath();
+        ctx.moveTo(bar.x, yTop);
+        ctx.lineTo(bar.x, yBottom);
+        ctx.moveTo(bar.x - capHalf, yTop);
+        ctx.lineTo(bar.x + capHalf, yTop);
+        ctx.moveTo(bar.x - capHalf, yBottom);
+        ctx.lineTo(bar.x + capHalf, yBottom);
+        ctx.stroke();
+      }
+
+      ctx.restore();
+    }
+  }
+},{
+  id: "showMax",
+  afterDatasetsDraw(chart) {
+    const { ctx } = chart;
+    const drawn_labels = [];
+
+    let count = chart.data.datasets.length;
+    if (BAR_TYPE === "line" && yValues[CUR_Y_AXIS].key === "iops") count--;
+
+    for (var i = 0; i < count; i++) {
+      const dataset = chart.data.datasets[i];
+      const dataset_meta = chart.getDatasetMeta(i);
+      if (!dataset_meta.data?.length || dataset_meta.hidden) continue;
+
+      ctx.save();
+      ctx.fillStyle = dataset.backgroundColor;
+      ctx.strokeStyle = dataset.backgroundColor;
+
+      if (BAR_TYPE === "bar") {
+        ctx.textAlign = "left";
+        for (var j = 0; j < dataset.data.length; j++) {
+          const bar = dataset_meta.data[j];
+          const text = separatedNumber(dataset.data[j].y);
+          ctx.save();
+          ctx.translate(bar.x, bar.y - 10);
+          ctx.rotate(-Math.PI / 2);
+          ctx.fillStyle = "black";
+          ctx.fillText(text, 0, 0);
+          ctx.restore();
+        }
+      } else {
+        const lastPoint = dataset.data[dataset.data.length-1];
+        const lastPointMeta = dataset_meta.data[dataset.data.length-1];
+        const text = separatedNumber(lastPoint.y);
+
+        const coord = { x: lastPointMeta.x + 10, y: lastPointMeta.y-6, w: ctx.measureText(text).width, h: 10 };
+
+        let goUp = coord.y;
+        let goDown = coord.y;
+
+        while (drawn_labels.some(r =>
+          goDown < r.y + r.h &&
+          goDown + coord.h > r.y
+        )) {
+          goDown += 4;
+        }
+        while (drawn_labels.some(r =>
+          goUp < r.y + r.h &&
+          goUp + coord.h > r.y
+        )) {
+          goUp -= 4;
+        }
+
+        if (coord.y-goUp < goDown-coord.y) coord.y = goUp;
+        else coord.y = goDown;
+
+        ctx.fillText(text, coord.x, coord.y+6);
+        drawn_labels.push({ ...coord, y: coord.y });
+      }
+    }
+  }
+});
+updateChart();

--- a/templates/bench-update-chart.jinja2.js
+++ b/templates/bench-update-chart.jinja2.js
@@ -104,6 +104,7 @@ function updateChart() {
     const graphData = filtered.map(d => ({
       x: logarithmic ? Math.log2(d[x_axis]) : d[x_axis],
       y: d[y_axis.key][0],
+      y_display: d[y_axis.key + '_display'],
       v: d[y_axis.key][1],
       data: d
     }));
@@ -113,6 +114,16 @@ function updateChart() {
 
   const maxXvalue = Math.max(...filtered_results[0].data.map(d => d[x_axis])) * (logarithmic ? 2 : 1) + (logarithmic ? 0 : 1);
 
+  const xCategories = BAR_TYPE === 'bar'
+    ? [...new Set(iopsData.flat().map(d => d.data[x_axis]))].sort((a,b) => a-b).map(String)
+    : null;
+
+  if (xCategories) {
+    iopsData = iopsData.map(data => data.map(d => ({...d, x: xCategories.indexOf(String(d.data[x_axis]))})));
+  }
+
+  const stacked = typeof STACKED !== 'undefined' && STACKED;
+
   const datasets = iopsData.map((data, idx) => ({
     data,
     label: filtered_results[idx].label.trim() || `Reached ${y_axis.prettyName}`,
@@ -120,7 +131,41 @@ function updateChart() {
     backgroundColor: filtered_results[idx].color,
     pointStyle: "circle",
     pointRadius: Math.floor(idx*0.2)+3,
+    ...(stacked ? { stack: 'stack0' } : {}),
   }));
+
+  if (typeof MAX_LINE_VALUE !== 'undefined' && MAX_LINE_VALUE !== null) {
+    const lineLabel = typeof MAX_LINE_LABEL !== 'undefined' ? MAX_LINE_LABEL : 'Max';
+    datasets.push({
+      type: 'line',
+      label: lineLabel,
+      data: xCategories
+        ? [{x: -0.5, y: MAX_LINE_VALUE}, {x: xCategories.length - 0.5, y: MAX_LINE_VALUE}]
+        : [...Array(Math.round(maxXvalue + 2)).keys()].map(x => ({ x: x - 1, y: MAX_LINE_VALUE })),
+      clip: false,
+      borderColor: 'rgba(0,0,0,0.5)',
+      backgroundColor: 'rgba(0,0,0,0)',
+      pointRadius: 0,
+      borderDash: [10, 5],
+      stack: 'line-max',
+    });
+  }
+  if (typeof COMP_LINE_VALUE !== 'undefined' && COMP_LINE_VALUE !== null) {
+    const lineLabel = typeof COMP_LINE_LABEL !== 'undefined' ? COMP_LINE_LABEL : 'Max';
+    datasets.push({
+      type: 'line',
+      label: lineLabel,
+      data: xCategories
+        ? [{x: -0.5, y: COMP_LINE_VALUE}, {x: xCategories.length - 0.5, y: COMP_LINE_VALUE}]
+        : [...Array(Math.round(maxXvalue + 2)).keys()].map(x => ({ x: x - 1, y: COMP_LINE_VALUE })),
+      clip: false,
+      borderColor: 'rgba(0,0,0,0.5)',
+      backgroundColor: 'rgba(0,0,0,0)',
+      pointRadius: 0,
+      borderDash: [10, 5],
+      stack: 'line-comp',
+    });
+  }
 
   if (y_axis.key === "iops" && BAR_TYPE === 'line') {
     const maxPeak = iopsData.flat().length ? Math.max(...iopsData.flat().map(d => d.data.peakiops)) : 1000;
@@ -148,20 +193,20 @@ function updateChart() {
       scales: {
         x: {
           type: "linear",
-          offset: x_axis === "fixed_freq",
+          offset: !!xCategories,
+          stacked,
           title: { display: true, text: `${xValues[CUR_X_AXIS].prettyName}` },
           min: 0,
-          max: logarithmic ? Math.log2(maxXvalue) : maxXvalue,
+          max: xCategories ? xCategories.length - 1 : logarithmic ? Math.log2(maxXvalue) : maxXvalue,
           ticks: {
+            stepSize: 1,
             callback: (v) => logarithmic ? Math.pow(2, v) : v,
           },
-          grid: {
-            drawTicks: true,
-            tickLength: 10
-          }
+          grid: { drawTicks: true, tickLength: 10 },
         },
         y: {
           title: { display: true, text: `${y_axis.prettyName} (${y_axis.unit})` },
+          stacked,
           min: 0,
           grace: BAR_TYPE === "bar" ? "20%" : 0,
           ticks: { callback: (v) => y_axis.key === "iops" ? v / 1e6 : v },
@@ -182,17 +227,18 @@ function updateChart() {
             title: () => "",
             label: (context) => {
               const d = context.raw;
+              const displayY = d.y_display ?? d.y;
               if (context.dataset.label.includes("Peak IOPS")) {
                 return `Peak IOPS: ${separatedNumber(d.y)}`;
               } else if (d.data.thr_sib) {
                 return [
-                  `${y_axis.prettyName}: ${separatedNumber(d.y)} ${y_axis.key ==="iops" ? "" : y_axis.unit}`,
+                  `${y_axis.prettyName}: ${separatedNumber(displayY)} ${y_axis.key ==="iops" ? "" : y_axis.unit}`,
                   `Standard Deviation: ${separatedNumber(d.v)}`,
                   `Hyper threads: ${d.data.hyperthreads}`
                 ];
               } else {
                 return [
-                  `${y_axis.prettyName}: ${separatedNumber(d.y)} ${y_axis.key ==="iops" ? "" : y_axis.unit}`,
+                  `${y_axis.prettyName}: ${separatedNumber(displayY)} ${y_axis.key ==="iops" ? "" : y_axis.unit}`,
                   `Standard Deviation: ${separatedNumber(d.v)}`
                 ];
               }
@@ -206,7 +252,7 @@ function updateChart() {
             }
           }
         },
-        errorBars: BAR_TYPE === 'bar',
+        errorBars: BAR_TYPE === 'bar' && !stacked,
         shadingArea: BAR_TYPE === 'line',
         showMax: BAR_TYPE === "bar" || document.getElementById("show-max-value").checked,
       },
@@ -382,6 +428,7 @@ Chart.register({
   afterDatasetsDraw(chart) {
     const { ctx } = chart;
     const drawn_labels = [];
+    const stacked = typeof STACKED !== 'undefined' && STACKED;
 
     let count = chart.data.datasets.length;
     if (BAR_TYPE === "line" && yValues[CUR_Y_AXIS].key === "iops") count--;
@@ -396,16 +443,30 @@ Chart.register({
       ctx.strokeStyle = dataset.backgroundColor;
 
       if (BAR_TYPE === "bar") {
-        ctx.textAlign = "left";
+        if (dataset.type === 'line') {
+          ctx.restore();
+          continue;
+        }
+
+        ctx.textAlign = stacked ? "center" : "left";
+
         for (var j = 0; j < dataset.data.length; j++) {
           const bar = dataset_meta.data[j];
-          const text = separatedNumber(dataset.data[j].y);
+          const value = dataset.data[j].y_display ?? dataset.data[j].y;
+          const text = value > 1000 ? separatedNumber(value) : value.toFixed(1);
+
           ctx.save();
-          ctx.translate(bar.x, bar.y - 10);
-          ctx.rotate(-Math.PI / 2);
-          ctx.fillStyle = "black";
+          if (stacked) {
+            ctx.translate(bar.x, bar.y + 10);
+            ctx.fillStyle = "white";
+          } else {
+            ctx.translate(bar.x, bar.y - 10);
+            ctx.rotate(-Math.PI / 2);
+            ctx.fillStyle = "black";
+          }
           ctx.fillText(text, 0, 0);
           ctx.restore();
+
         }
       } else {
         const lastPoint = dataset.data[dataset.data.length-1];

--- a/templates/bench-update-chart.jinja2.js
+++ b/templates/bench-update-chart.jinja2.js
@@ -81,10 +81,10 @@ function updateChart() {
 
   environments.forEach(({key}) => {
     const selectedRadio = document.querySelector(`input[name="${key}"]:checked`).value;
-    if (selectedRadio === 0) {
-      filtered_results = filtered_results.map(elem => ({...elem, data: data.filter(d => d[key] === false)}));
-    } else if (selectedRadio === 1) {
-      filtered_results = filtered_results.map(elem => ({...elem, data: data.filter(d => d[key] === true)}));
+    if (selectedRadio === "0") {
+      filtered_results = filtered_results.map(elem => ({...elem, data: elem.data.filter(d => d[key] == false)}));
+    } else if (selectedRadio === "1") {
+      filtered_results = filtered_results.map(elem => ({...elem, data: elem.data.filter(d => d[key] == true)}));
     }
   });
   filtered_results = filtered_results.filter(({data}) => data.length);

--- a/templates/benchmark-io.jinja2
+++ b/templates/benchmark-io.jinja2
@@ -65,7 +65,7 @@ const environments = [
 
 let CUR_X_AXIS = 2;
 let CUR_Y_AXIS = 0;
-const radioDefaults = [128, 8, 16, 512, "performance"];
+const radioDefaults = [128, 8, 16, 512, "performance", "bdevperf"];
 
 const BAR_TYPE = 'line';
 {% include "bench-update-chart.jinja2.js" %}

--- a/templates/benchmark-pcie.jinja2
+++ b/templates/benchmark-pcie.jinja2
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Data Graph</title>
+<style>
+{% include "bench-style.jinja2.css" %}
+
+.controls:has(.x),
+.controls:has(.y),
+[label-for="tool"],
+#toolRadios,
+[label-for="show-max-value"],
+#show-max-value {
+  display: none;
+}
+
+label:has([value="undefined"]) {
+  pointer-events: none;
+  opacity: 0.2;
+}
+</style>
+</head>
+<body>
+
+{% include "bench-dom.jinja2.html" %}
+
+<script>
+const colours = ["blue", "red", "olive", "pink", "lime", "purple", "cyan", "orange", "violet", "skyblue", "brown", "green"];
+
+let results = [
+  {%- for dataset in datasets %}
+  {
+    label: "{{dataset.label}}",
+    data: [{% for d in dataset.data %}
+      {{ d }},
+    {%- endfor %}]
+      .sort((a,b) => a.ncpus - b.ncpus)
+      .map(d => ({
+        ...d,
+        tool: d.tool === "xnvmeperf" ? `${d.tool}-${d.backend}` : d.tool,
+        fixed_freq: d.fixed_freq ? d.fixed_freq : d.cpu_governor,
+    {%- if "Using thread siblings" in dataset.label %}
+        hyperthreads: d.ncpus, ncpus: Math.ceil(d.ncpus / 2),
+    {% endif %}
+      }))
+  },
+  {%- endfor %}
+]
+  .sort((a,b) => a.label.localeCompare(b.label));
+
+const getXvalues = () => {
+  const allData = results.map(({data}) => data).flat();
+  return [
+    {elemId: "qdepthRadios", key: "qdepth", prettyName: "Queue Depth"},
+    {elemId: "cpusRadios", key: "ncpus", prettyName: "Number of Physical Cores"},
+    {elemId: "devicesRadios", key: "ndevs", prettyName: "Number of Devices"},
+    {elemId: "iosizeRadios", key: "iosize", prettyName: "I/O Size"},
+    {elemId: "cpufreqRadios", key: "fixed_freq", prettyName: "CPU Frequency or Governor" },
+    {elemId: "toolRadios", key: "tool", prettyName: "Tool" },
+    {elemId: "turboBoostRadios", key: "turbo", prettyName: "Turbo Boost" },
+    {elemId: "smtRadios", key: "smt", prettyName: "SMT" },
+    {elemId: "htRadios", key: "thr_sib", prettyName: "Using Thread siblings" },
+    {elemId: "stressRadios", key: "stress", prettyName: "Stress" },
+  ].map(s => ({...s, set: [...new Set(allData.map(d => d[s.key]))].sort((a,b) => a - b) }));
+}
+
+const xValues = getXvalues();
+const yValues = [{ key: "mibs", prettyName: "Bandwidth", unit: "GB/s" }];
+const environments = [
+];
+
+let CUR_X_AXIS = 3;
+let CUR_Y_AXIS = 0;
+const radioDefaults = [128, 1, 16, 512, "performance", "upcie-cuda", 1, 1, 0, 0];
+
+/* Split datasets by reporter instead of environment */
+const splitDatasetOnReporter = () => {
+  let all = results.flatMap(r => r.data);
+
+  results = [
+    {label: "upcie-cuda (reported by xnvmeperf)", color: colours[0] , data: []},
+    {label: "upcie-cuda (reported by dcgmi)", color: colours[1] , data: []},
+  ];
+  for (let i = 0; i < all.length; i++) {
+    const d = all[i];
+    d.mibs = d.mibs.map(n => n * 1024*1024 / 1e9);
+    results[0].data.push(d);
+    results[1].data.push({...d, "mibs": d.dcgm ? d.dcgm.map((n, idx) => n / 1e9 - d.mibs[idx]) : [0,0], "mibs_display": d.dcgm ? d.dcgm[0] / 1e9 : 0});
+  }
+
+  return results;
+}
+results = splitDatasetOnReporter();
+
+const BAR_TYPE = 'bar';
+const STACKED = true;
+const MAX_LINE_VALUE = 64;
+const MAX_LINE_LABEL = `PCIe Gen5 x16 line rate (${MAX_LINE_VALUE.toFixed(1)} GB/s)`;
+const COMP_LINE_VALUE = {{cuda_bandwidth}};
+const COMP_LINE_LABEL = `p2pBandwidthTest (${COMP_LINE_VALUE.toFixed(1)} GB/s)`;
+
+{% include "bench-update-chart.jinja2.js" %}
+
+</script>
+
+</body>
+</html>

--- a/templates/benchmark-tools.jinja2
+++ b/templates/benchmark-tools.jinja2
@@ -12,6 +12,11 @@
 #show-max-value {
   display: none;
 }
+
+label:has([value="undefined"]) {
+  pointer-events: none;
+  opacity: 0.2;
+}
 </style>
 </head>
 <body>
@@ -67,16 +72,16 @@ const radioDefaults = [128, 1, 16, 512, "performance", 1, 1, 1, 0];
 
 /* Split datasets by tool instead of environment */
 const splitDatasetOnTool = () => {
-  let all = results[0];
+  let all = results.flatMap(r => r.data);
 
   results = [];
-  const tools = [...new Set(all.data.map(d => d.tool))].sort();
+  const tools = [...new Set(all.map(d => d.tool))].sort();
   for (let i = 0; i < tools.length; i++) {
     const tool = tools[i];
     results.push({
       label: tool,
       color: colours[i % colours.length],
-      data: all.data.filter(d => d.tool === tool).map(d => ({...d, peakiops: d.iops })),
+      data: all.filter(d => d.tool === tool).map(d => ({...d, peakiops: d.iops })),
     });
   }
 


### PR DESCRIPTION
 - Adds `DcgmHelper`, a new script that starts `dcgmi dmon` in the
    background during a benchmark run and returns per-field statistics
    (mean, p95, and raw samples) for post-processing
  - Integrates `DcgmHelper` into `BenchHelper` for `upcie-cuda` runs,
    storing dcgm field data alongside IOPS and bandwidth in the result JSON
  - Adds `tasks/bench_pcie.yaml`, a dedicated task that runs `xnvmeperf`
    with the `upcie-cuda` backend across multiple I/O sizes to characterise
    PCIe bandwidth during P2P transfers to GPU memory
  - Fixes a pre-existing missing return tuple (`-1` → `-1, None`) in the
    unknown-tool branch of `BenchHelper.run_benchmark`