### PR TITLE
Further work on strengthening the story telling

### DIFF
--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -944,7 +944,7 @@ can parse the on-disk format of the XFS file system, including superblocks,
 allocation groups, inodes, and extent trees, to extract extent information
 independently of the file system mount state.
 
-## Transition to Architecture
+## Summary
 
 The background above summarizes the mechanisms and constraints that shape modern
 storage I/O, spanning PCIe transport and routing, memory and DMA visibility,

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -868,17 +868,34 @@ when building systems where devices interact without traditional OS mediation.
 (sec-filesystems)=
 ## Files and File Systems
 
-File systems define on disk layout, metadata, and allocation.
+File systems sit above the block device and map the names and byte offsets that
+applications use to the physical block addresses that storage devices require.
+When an application reads from a file, the operating system resolves the file
+path through the Virtual File System (VFS) to an inode, determines which
+physical blocks cover the requested byte range from the file's extent tree, and
+issues block I/O to those addresses. Under OS-mediated I/O this translation is
+handled transparently by the kernel; when I/O bypasses the kernel it becomes an
+explicit responsibility of the I/O stack.
 
-**Extents** represent contiguous file regions through a starting block and
-length.
+For device-initiated I/O, accelerators cannot perform pathname resolution or
+query kernel metadata structures at runtime. The logical-to-physical block
+mapping must therefore be extracted on the host in advance and made available
+to the initiating device. **Extents** express this mapping: each extent
+identifies a contiguous file region by its starting logical block and length. A
+complete extent tree covers a file's full address space and is the primary
+structure used to translate file offsets into physical block ranges without
+kernel involvement.
 
-**On disk format** encodes superblocks, inodes, allocation groups, and B tree
-metadata.
-
-**FIEMAP** reveals the physical extents of a file but requires the file system
-to be mounted and does not expose all metadata needed for accelerator resident
-scheduling.
+Two mechanisms exist for obtaining this information from a file system. The
+**FIEMAP** ioctl queries the kernel for a file's physical extents across any
+mounted file system, but depends on the file system being mounted and does not
+expose all on-disk structures needed for offline extent resolution. Direct
+decoding of the **on-disk format** does not require a mounted file system and
+provides a complete view of the mapping, enabling extent information to be
+pre-loaded into a host-resident cache independently of the kernel storage stack.
+File systems encode extent metadata alongside structures such as superblocks and
+inodes, with the specific layout varying by implementation. XFS, for example,
+organizes this metadata into allocation groups and B-tree extent trees.
 
 (sec-posix)=
 ## POSIX Semantics

--- a/docs/src/conclusion.md
+++ b/docs/src/conclusion.md
@@ -2,19 +2,50 @@
 # Conclusion
 
 This work introduced AiSIO as a class of system software architectures and HOMI
-as a reference architecture within it, and presented a proof-of-concept
-implementation. The experimental evaluation to date covers two synthetic
-benchmark studies in a single hardware environment.
+as a reference architecture within it, and presented a reference implementation.
+The experimental evaluation to date covers five synthetic benchmark studies in a
+single hardware environment, structured to characterize the resource efficiency
+of the uPCIe and uPCIe-cuda data paths from the ground up.
 
-The CPU-initiated benchmark showed that approximately 62 million IOPS across 16
-NVMe devices is achievable with SPDK bdevperf using only 8 physical cores, with
-performance scaling linearly with both device count and core count. The NVMe
-driver comparison showed that the **upcie** backend reaches approximately 2.5
-times the IOPS of the **spdk** backend when the benchmark tool and xNVMe
-abstraction layer are held constant, consistent with uPCIe's leaner command
-path. A comparison of the **upcie** and **upcie-cuda** backends further showed
-that routing the data path through P2P DMA to GPU device memory does not
-measurably affect command submission throughput in this synthetic workload.
+The {ref}`sec-experiments-cpu-initiated` experiment established a ceiling of
+approximately 62 million IOPS across 16 NVMe devices, requiring 8 physical cores
+running at full utilization under busy-polling, with performance scaling linearly
+with both device count and core count. This serves as the roofline and CPU cost
+reference against which the subsequent experiments are compared.
+
+The {ref}`sec-experiments-tool-comparison` experiment showed that successive
+layers of the SPDK stack each impose measurable overhead, and that replacing the
+SPDK driver with the leaner uPCIe driver yields approximately 2.5 times the IOPS
+when the benchmark tool and xNVMe abstraction layer are held constant. More
+significantly, the uPCIe path reaches the device IOPS roofline with only three CPU
+threads, fewer than half the cores required by the SPDK baseline. Routing the
+data path through P2P DMA to GPU device memory via upcie-cuda does not measurably
+affect command throughput, validating a core assumption of the AiSIO design.
+
+The {ref}`sec-experiments-pcie-bandwidth` experiment showed that a single CPU
+thread driving four NVMe devices is sufficient to saturate the PCIe Gen5 x16 link
+at I/O sizes of 4 KiB and above, pushing total PCIe traffic to approximately
+57.8 GB/s and reaching approximately 90% of the line rate. Protocol overhead
+accounts for a consistent 28% above payload bandwidth across all tested I/O sizes
+and operating regimes, indicating it scales with bytes transferred rather than
+operation count.
+
+The device-initiated experiments examined how GPU threads can drive NVMe I/O
+directly. The {ref}`sec-experiments-cuda-iosize` experiment showed that the
+thread count required to saturate the PCIe link decreases monotonically with
+I/O size: at 64 KiB just 32 CUDA threads across 16 devices suffice, while at
+512 bytes the constraint shifts to device IOPS rather than link capacity. The
+{ref}`sec-experiments-cuda-qdepth` experiment showed that a single queue per
+device cannot reach the device IOPS roofline regardless of queue depth, and that
+adding a second queue breaks this ceiling. With 4096 total CUDA threads, the
+61.7 million IOPS roofline is reached under 512-byte device-initiated I/O, and
+additional queues beyond four per device add thread count without further gain.
+
+Taken together, these results demonstrate that eliminating software abstraction
+layers from the I/O path enables full hardware utilization with a fraction of the
+CPU resources required by conventional approaches, and that the P2P data path to
+GPU memory can be saturated with similarly modest resource requirements under both
+CPU-initiated and device-initiated I/O.
 
 Several parts of the plan remain open. File-based benchmarks comparing the
 AiSIO uPCIe path against GDS and POSIX have not yet been run. The HOMI PoC

--- a/docs/src/conclusion.md
+++ b/docs/src/conclusion.md
@@ -8,7 +8,7 @@ single hardware environment, structured to characterize the resource efficiency
 of the uPCIe and uPCIe-cuda data paths from the ground up.
 
 The {ref}`sec-experiments-cpu-initiated` experiment established a ceiling of
-approximately 62 million IOPS across 16 NVMe devices, requiring 8 physical cores
+approximately 61.7 million IOPS across 16 NVMe devices, requiring 8 physical cores
 running at full utilization under busy-polling, with performance scaling linearly
 with both device count and core count. This serves as the roofline and CPU cost
 reference against which the subsequent experiments are compared.

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -128,7 +128,7 @@ cijoe --monitor \
     tasks/bench_tools.yaml
 ```
 
-#### PCIe Bandwidth Saturation (``bench_pcie.yaml``)
+#### CPU-Initiated P2P I/O: PCIe Bandwidth Saturation (``bench_pcie.yaml``)
 
 Characterizes PCIe link utilization on the **upcie-cuda** path by running
 xnvmeperf at varying I/O sizes while collecting hardware-level PCIe bandwidth

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -1,6 +1,11 @@
 (sec-experimental-framework)=
 # Experimental Framework
 
+This section describes the system configuration, software stack, and benchmark
+workflows used to produce the experimental results. It covers both the synthetic
+NVMe benchmarks that characterize raw I/O performance and the file-based
+benchmarks that evaluate end-to-end dataset loading.
+
 ## System Setup
 
 All environment provisioning is automated using

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -113,7 +113,7 @@ cijoe --monitor \
     tasks/bench_io.yaml
 ```
 
-#### Benchmark Tool Comparison (``bench_tools.yaml``)
+#### CPU-initiated I/O: Software Abstraction Overhead (``bench_tools.yaml``)
 
 Runs bdevperf, SPDK NVMe Perf, and xnvmeperf (with the spdk, upcie, and
 upcie-cuda backends) under identical parameters to isolate the effect of

--- a/docs/src/experiments/cpu_initiated.md
+++ b/docs/src/experiments/cpu_initiated.md
@@ -354,7 +354,7 @@ Results of parameterization C with different devices.
 ## Summary
 
 The optimal configuration — "performance" governor, turbo boost enabled, SMT
-enabled, queue depth 128, 512-byte I/O — achieves approximately 62 million IOPS
+enabled, queue depth 128, 512-byte I/O — achieves approximately 61.7 million IOPS
 across 16 devices using 8 physical cores. Performance scales linearly with both
 device count and core count up to the device capacity ceiling, and the per-device
 capacity observed in single-device runs (3.86 million IOPS) serves as the roofline

--- a/docs/src/experiments/device_initiated_qdepth.md
+++ b/docs/src/experiments/device_initiated_qdepth.md
@@ -3,8 +3,8 @@
 
 The previous experiment showed that at 512-byte I/O the PCIe link cannot be
 saturated regardless of thread count, and that the constraint is device IOPS,
-which was established to be ~62 M IOPS in the CPU-initiated experiment. This
-experiment holds I/O size fixed at 512 bytes and sweeps queue depth across
+which was established to be 61.7 M IOPS in the {ref}`sec-experiments-cpu-initiated` experiment.
+This experiment holds I/O size fixed at 512 bytes and sweeps queue depth across
 a wide range, with the number of queues per device as the secondary variable.
 The aim is to identify the queue depth at which each queue-count configuration
 saturates under device-initiated I/O.

--- a/docs/src/experiments/index.md
+++ b/docs/src/experiments/index.md
@@ -3,11 +3,12 @@
 This section presents the experiments conducted to evaluate AiSIO.
 The experiments are structured to build on each other. The first establishes the
 CPU-initiated IOPS ceiling and the optimal system configuration. The second
-isolates the effect of benchmark tool and NVMe driver choice. The third identifies
-where the I/O size crosses from IOPS-bound to bandwidth-bound operation. The final
-two examine device-initiated I/O, first varying I/O size to find the saturation
-boundary, then varying queue depth and queue count to find the combination that
-reaches device saturation.
+quantifies the software abstraction overhead at each layer of the CPU-initiated
+I/O stack and shows how much of that overhead the uPCIe path eliminates. The
+third identifies where the I/O size crosses from IOPS-bound to bandwidth-bound
+operation. The final two examine device-initiated I/O, first varying I/O size to
+find the saturation boundary, then varying queue depth and queue count to find
+the combination that reaches device saturation.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/src/experiments/index.md
+++ b/docs/src/experiments/index.md
@@ -1,5 +1,14 @@
 # Experiments
 
+This section presents the experiments conducted to evaluate AiSIO.
+The experiments are structured to build on each other. The first establishes the
+CPU-initiated IOPS ceiling and the optimal system configuration. The second
+isolates the effect of benchmark tool and NVMe driver choice. The third identifies
+where the I/O size crosses from IOPS-bound to bandwidth-bound operation. The final
+two examine device-initiated I/O, first varying I/O size to find the saturation
+boundary, then varying queue depth and queue count to find the combination that
+reaches device saturation.
+
 ```{toctree}
 :maxdepth: 1
 cpu_initiated

--- a/docs/src/experiments/pcie_saturation.md
+++ b/docs/src/experiments/pcie_saturation.md
@@ -1,22 +1,25 @@
 (sec-experiments-pcie-bandwidth)=
-# PCIe Bandwidth Saturation
+# CPU-Initiated P2P I/O: PCIe Bandwidth Saturation
 
-The preceding experiments were conducted at 512-byte I/O, where each command
-carries so little data that the PCIe link operates far below capacity even at
-tens of millions of IOPS — the bottleneck is how fast commands can be submitted
-and completed, not how much data the link can carry. At larger I/O sizes, however, the
-bottleneck shifts: as each command carries more payload, the PCIe link itself
-becomes the limiting factor rather than device IOPS, CPU throughput, or GPU
-capacity. Identifying where this transition occurs is important for understanding
-the practical operating range of the P2P data path and for interpreting the
-device-initiated I/O experiments that follow.
+The {ref}`sec-experiments-tool-comparison` experiment showed that the
+**upcie-cuda** backend matches **upcie** in IOPS within measurement variance,
+confirming that routing data through P2P DMA to GPU device memory does not
+measurably affect command throughput. Both preceding experiments were conducted
+at 512-byte I/O, where each command carries so little data that the PCIe link
+operates far below capacity even at tens of millions of IOPS. The bottleneck
+is how fast commands can be submitted and completed, not how much data the link
+can carry. At larger I/O sizes the bottleneck shifts: as each command carries
+more payload, the PCIe link itself becomes the limiting factor. The question
+this experiment asks is how few CPU resources and devices are required to reach
+that point.
 
-This experiment sweeps I/O size across three points — 512, 4096, and 8192 bytes —
-and measures both the payload bandwidth reported by xnvmeperf and the total PCIe
-receive traffic observed by DCGM at the GPU endpoint. The gap between the two
-reveals the share of the link consumed by NVMe and PCIe protocol traffic rather
-than payload. A reference peak P2P bandwidth from ``p2pBandwidthLatencyTest``
-establishes the practical ceiling of the link under sustained P2P transfers.
+This experiment fixes CPU threads at 1 and devices at 4, then sweeps I/O size
+across three points (512, 4096, and 8192 bytes), measuring both the payload
+bandwidth reported by xnvmeperf and the total PCIe receive traffic observed by
+DCGM at the GPU endpoint. The gap between the two reveals the share of the link
+consumed by NVMe and PCIe protocol traffic rather than payload. A reference peak
+P2P bandwidth from ``p2pBandwidthLatencyTest`` establishes the practical ceiling
+of the link under sustained P2P transfers.
 
 ## Independent Variables
 
@@ -79,7 +82,7 @@ NVMe SSDs transferring data P2P to a PCIe Gen5 GPU via the upcie-cuda backend.
 Each bar is stacked: the lower segment is the payload bandwidth reported by
 xnvmeperf; the upper segment is the remainder observed by DCGM. The dashed lines
 mark the PCIe Gen5 x16 line rate (64.0 GB/s) and the reference P2P bandwidth from
-``p2pBandwidthLatencyTest`` (55.98 GB/s).
+``p2pBandwidthLatencyTest`` (56.1 GB/s).
 ```
 
 ### Small I/O: Link Underutilized
@@ -87,32 +90,37 @@ mark the PCIe Gen5 x16 line rate (64.0 GB/s) and the reference P2P bandwidth fro
 With 512-byte payloads, xnvmeperf reports 7.9 GB/s payload bandwidth and DCGM
 measures 10.1 GB/s total PCIe receive traffic, corresponding to approximately 16%
 of the PCIe Gen5 x16 line rate. This is consistent with the IOPS-bound regime
-observed in {ref}`sec-experiments-tool-comparison-results`: at small I/O sizes the constraint
-is NVMe command throughput, not PCIe link capacity.
+observed in the {ref}`software abstraction overhead results
+<sec-experiments-tool-comparison-results>`: at small I/O sizes the constraint is
+NVMe command throughput, not PCIe link capacity.
 
 ### Large I/O: Link Approaches Saturation
 
 With 4096- and 8192-byte payloads, DCGM measures approximately 57.8 GB/s in both
-cases, approaching the ``p2pBandwidthLatencyTest`` reference of 55.98 GB/s and
+cases, exceeding the ``p2pBandwidthLatencyTest`` reference of 56.1 GB/s and
 reaching approximately 90% of the 64.0 GB/s line rate. The identical result at
 both I/O sizes indicates that the PCIe link, rather than NVMe command throughput,
 is the binding constraint at these I/O sizes. xnvmeperf reports approximately
-45.2 GB/s of payload bandwidth for both sizes.
+45.2 GB/s of payload bandwidth for both sizes. This saturation is achieved
+with a single CPU thread and only four NVMe devices, demonstrating that the
+uPCIe-cuda path requires minimal CPU and device resources to fully utilize the
+PCIe link at larger I/O sizes.
 
 ### PCIe Protocol Overhead
 
 Across all three I/O sizes, the total PCIe receive bandwidth measured by DCGM
 exceeds the payload bandwidth reported by xnvmeperf by a consistent factor of
-approximately 1.28. The consistency of this ratio across I/O sizes and IOPS levels
-indicates that the excess scales with bytes transferred rather than with operation
-count.
+approximately 1.28. The ratio holds across both the IOPS-bound regime at 512 bytes
+and the bandwidth-bound regime at 4096 and 8192 bytes, spanning a range where IOPS
+differ by an order of magnitude. This indicates that the excess scales with bytes
+transferred rather than with operation count, making the 28% overhead a stable
+characterization of the P2P data path regardless of operating regime.
 
 ## Summary
 
-At small I/O sizes the P2P link operates far below capacity; at 4 KiB and above,
-total PCIe traffic approaches the practical P2P ceiling (~55.98 GB/s), reaching
-approximately 90% of the Gen5 x16 line rate. Protocol overhead accounts for a
-consistent 28% above payload bandwidth across all tested I/O sizes, indicating it
-scales with bytes transferred rather than operation count. The device-initiated
-experiments that follow use the same upcie-cuda path and reference the P2P
-bandwidth ceiling established here.
+At small I/O sizes the P2P link operates far below capacity. At 4 KiB and above,
+a single CPU thread driving four NVMe devices is sufficient to push total PCIe
+traffic to approximately 57.8 GB/s, exceeding the practical P2P ceiling of
+56.1 GB/s and reaching approximately 90% of the Gen5 x16 line rate. Protocol
+overhead accounts for a consistent 28% above payload bandwidth across all tested
+I/O sizes, indicating it scales with bytes transferred rather than operation count.

--- a/docs/src/experiments/tool_comparison.md
+++ b/docs/src/experiments/tool_comparison.md
@@ -1,19 +1,23 @@
 (sec-experiments-tool-comparison)=
-# Benchmark Tool Comparison
+# CPU-initiated I/O: Software Abstraction Overhead
 
-The preceding experiment established the CPU-initiated IOPS ceiling using bdevperf
-and SPDK. The AiSIO proof-of-concept, however, uses xNVMe with the uPCIe backend —
-a different benchmark tool, a different NVMe abstraction layer, and a different
-NVMe driver. To make comparisons across I/O path architectures meaningful, it is
-necessary to first understand how much tool and driver choice alone account for
-differences in results.
+The {ref}`sec-experiments-cpu-initiated` experiment established the
+CPU-initiated IOPS ceiling using bdevperf and SPDK. As discussed in the
+introduction, the software stack between an application and the NVMe controller,
+e.g., bdev abstraction and driver runtime, imposes overhead that consumes CPU
+cycles and limits throughput. The AiSIO reference implementation targets this
+overhead directly, replacing SPDK with the uPCIe backend, which constructs and
+submits NVMe commands without an intervening driver runtime or intermediate
+copies.
 
-This experiment holds the hardware environment and I/O parameters fixed at the
-values from the preceding experiment and varies only the benchmark tool and NVMe
-driver, isolating their individual contributions to measured IOPS. It also
-introduces the upcie-cuda backend, which places data buffers in GPU device memory
-and transfers them via P2P DMA — the same data path exercised in the PCIe
-bandwidth and device-initiated experiments that follow.
+This experiment isolates the contribution of each abstraction layer by holding
+hardware and I/O parameters fixed while varying only the benchmark tool and
+NVMe driver. Stepping from bdevperf through SPDK NVMe Perf to xnvmeperf with
+the uPCIe backend quantifies the overhead attributable to each layer and shows
+how much of the CPU-initiated ceiling the uPCIe path can recover. The experiment
+also introduces the upcie-cuda backend, which places data buffers in GPU device
+memory and transfers them via P2P DMA, combining the leaner software path with
+elimination of the host DRAM copy.
 
 The tools under comparison are:
 
@@ -122,39 +126,38 @@ The independent variables are:
 | Tool and backend      | { bdevperf, perf, xnvmeperf+spdk, xnvmeperf+upcie, xnvmeperf+upcie-cuda } |
 | Queue depth           | { 128 }                                                                   |
 | I/O size              | { 512 }                                                                   |
-| Number of CPU threads | { 1, 2 }                                                                  |
+| Number of CPU threads | { 1, 2, 3, 4 }                                                            |
 | Number of devices     | { 16 }                                                                    |
 
 (sec-experiments-tool-comparison-results)=
 ## Results
 
-This section presents the results of the benchmark tool comparison experiment
-described in {ref}`sec-experiments-tool-comparison`. The experiment has two
-sides: first, comparing bdevperf, SPDK NVMe Perf, and xnvmeperf with the SPDK
-backend, where all three tools exercise the same underlying SPDK NVMe driver but
-differ in the software layers above it; second, comparing xnvmeperf with the
-SPDK backend against xnvmeperf with the uPCIe backends (``upcie`` and
-``upcie-cuda``), where the tool and xNVMe abstraction layer are held constant,
-with the **upcie** and **upcie-cuda** backends further isolating the effect of
-P2P buffer placement by sharing the same uPCIe driver.
+This section presents the results of the benchmark tool comparison experiment.
+The results are structured in two parts. The first steps through the SPDK-based
+tools: bdevperf, SPDK NVMe Perf, and xnvmeperf with the SPDK backend. This
+is to quantify the overhead of each layer within the SPDK stack. The second
+compares the uPCIe backends against the SPDK baseline to show how much of that
+overhead the leaner driver eliminates, and at what CPU cost the device roofline
+is reached.
 
 ```{figure} /barplot-tool.png
-:alt: Results for running benchmarks with different tools and drivers
+:alt: IOPS vs. number of CPU threads for each benchmark tool and NVMe driver
 :width: 700px
 :align: center
 
-Results of running the experiment on a single core with one or two CPU threads.
+IOPS as a function of CPU thread count for each tool and backend configuration,
+across 16 NVMe devices at queue depth 128 and 512-byte I/O.
 ```
 
-% (tool):          (1 CPU thread) (2 CPU threads)
-% bdevperf:              6340302     7408712
-% spdk_nvme_perf:       10712199    15184483
-%   -> without rdtsc:   12668440    15519287
-% xnvmeperf-spdk:       14876017    17943035
-% xnvmeperf-upcie:      37533134    47606095
-% xnvmeperf-upcie-cuda: 37046501    47858195
+% (tool):          (1 CPU thread) (2 CPU threads) (3 CPU threads) (4 CPU threads)
+% bdevperf:              6340302        7408712       16200000       18200000
+% spdk_nvme_perf:       10712199       15184483       28800000       33400000
+%   -> without rdtsc:   12668440       15519287
+% xnvmeperf-spdk:       14876017       17943035       32800000       36100000
+% xnvmeperf-upcie:      37533134       47606095       61000000       60200000
+% xnvmeperf-upcie-cuda: 37046501       47858195       61600000       61700000
 
-### Benchmarking Tools Comparison
+### Stripping Away SPDK Layers
 
 #### bdevperf vs. perf
 
@@ -162,15 +165,18 @@ Results of running the experiment on a single core with one or two CPU threads.
 underlying SPDK NVMe driver, so the difference between them reflects the SPDK bdev
 abstraction layer alone. **perf** reaches approximately 70% higher IOPS than
 **bdevperf** with one thread, and approximately twice the IOPS with two threads,
-indicating that the bdev layer imposes substantial cost on this workload.
+indicating that the bdev layer imposes substantial cost on this workload. The
+gap narrows at three and four threads, where bdevperf reaches 16.2 and 18.2 million
+IOPS respectively, while perf reaches 28.8 and 33.4 million. However, the bdev
+overhead remains significant across all thread counts tested.
 
 #### perf vs. xnvmeperf (SPDK Backend)
 
-**xnvmeperf** with the SPDK backend reaches approximately 39% higher IOPS than **perf**
-with one thread, and approximately 18% higher with two threads. As described in
-{ref}`sec-experiments-tool-comparison`, this comparison is confounded: both the
-benchmark tool and the xNVMe abstraction layer differ simultaneously, and the
-result cannot be attributed to either factor alone.
+**xnvmeperf** with the SPDK backend reaches approximately 39% higher IOPS than
+**perf** with one thread, and approximately 18% higher with two threads. As
+described above, this comparison is confounded: both the benchmark tool and
+the xNVMe abstraction layer differ simultaneously, and the result cannot be
+attributed to either factor alone.
 
 A known contributor on the tool side is that **perf** performs per-I/O latency
 tracking on the hot path. On every submission, it calls ``spdk_get_ticks()`` to
@@ -191,31 +197,46 @@ latency rather than paying it in full. Even with latency tracking removed,
 **xnvmeperf** remains ahead, indicating that tool design differences beyond
 latency tracking also contribute to the result.
 
-### NVMe Driver Comparison
+At three and four threads, xnvmeperf with the SPDK backend reaches 32.8
+and 36.1 million IOPS respectively, still well below the ~62 million IOPS
+device roofline. Across all thread counts, the SPDK-based tools collectively
+demonstrate that layered software overhead accumulates: removing layers yields
+meaningful gains at each step, but the combined overhead of the SPDK stack
+places a ceiling that more threads alone cannot overcome.
+
+### Replacing the SPDK Driver with uPCIe
 
 Since all configurations in this section use **xnvmeperf**, backends are referred
 to by name alone for brevity.
 
 With the benchmark tool and xNVMe abstraction layer held constant, the **upcie**
 backend reaches approximately 2.5 times the IOPS of the **spdk** backend across
-both thread counts. As noted in {ref}`sec-experiments-tool-comparison`, this
-comparison reflects differences in NVMe driver design, including the abstraction
-layers within each driver, rather than the xNVMe abstraction layer, which is
-held constant across both configurations. The **spdk** backend relies on SPDK,
-which routes completions through ``spdk_nvme_qpair_process_completions`` operating
-within SPDK's own runtime. The **upcie** backend relies on uPCIe, which uses a
-leaner implementation that polls the completion queue directly by reading phase
-bits and writes doorbells through direct MMIO, without an intervening runtime
-layer. A contributing factor is that SPDK performs significantly more memory
-operations per I/O: it copies the 64-byte command into an internal request
-structure, clears approximately 315 bytes of request state via ``memset``, and
-copies the payload metadata before the command reaches the submission queue.
-uPCIe avoids these intermediate copies, referencing the command directly and
-writing it once to the submission queue.
+both thread counts. As noted above, this comparison reflects differences in NVMe
+driver design, including the abstraction layers within each driver, rather than
+the xNVMe abstraction layer, which is held constant across both configurations.
+The **spdk** backend relies on SPDK, which routes completions through
+``spdk_nvme_qpair_process_completions`` operating within SPDK's own runtime.
+The **upcie** backend relies on uPCIe, which uses a leaner implementation that
+polls the completion queue directly by reading phase bits and writes doorbells
+through direct MMIO, without an intervening runtime layer. A contributing factor
+is that SPDK performs significantly more memory operations per I/O: it copies
+the 64-byte command into an internal request structure, clears approximately
+315 bytes of request state via ``memset``, and copies the payload metadata
+before the command reaches the submission queue. uPCIe avoids these intermediate
+copies, referencing the command directly and writing it once to the submission
+queue.
+
+At three CPU threads, both **upcie** and **upcie-cuda** reach approximately
+61 million IOPS, meeting the device roofline established in the
+{ref}`sec-experiments-cpu-initiated` experiment. Adding a fourth thread
+brings no further improvement, confirming that the device, not the CPU, is
+the bottleneck at three threads. By contrast, xnvmeperf with the SPDK backend
+reaches only 36.1 million IOPS at four threads, never approaching the ceiling
+within the thread counts tested.
 
 The **upcie-cuda** backend produces results within approximately 1% of the
-**upcie** backend in both thread configurations. Since the two backends share
-the same NVMe driver and differ only in buffer placement, this indicates that
+**upcie** backend across all thread counts. Since the two backends share the
+same NVMe driver and differ only in buffer placement, this indicates that
 routing the data path through P2P DMA to GPU device memory does not measurably
 affect the IOPS achieved by the NVMe command submission path under these
 conditions.
@@ -229,7 +250,17 @@ of SPDK when the benchmark tool and xNVMe layer are held constant, a result that
 be attributed to uPCIe's leaner command path and avoidance of intermediate memory
 copies. Third, and most directly relevant to the AiSIO design, routing data through
 P2P DMA to GPU device memory does not measurably affect command throughput: the
-upcie-cuda backend matches the upcie backend within measurement variance. This last
-finding validates a core assumption of the AiSIO P2P architecture and motivates
-the PCIe bandwidth characterization that follows, which examines how much of the
-available link capacity the upcie-cuda path actually uses.
+upcie-cuda backend matches the upcie backend within measurement variance, validating
+a core assumption of the AiSIO P2P architecture.
+
+Notably, the upcie and upcie-cuda backends achieve approximately 37 million
+IOPS with a single CPU thread and approximately 47 million IOPS with two threads
+across 16 devices. At three threads, both backends reach the device roofline
+of ~62 million IOPS and adding a fourth thread brings no further improvement,
+thus confirming device saturation. The {ref}`sec-experiments-cpu-initiated`
+experiment required 8 physical cores to reach the same ceiling; the uPCIe path
+reaches it with three CPU threads, using fewer than half the cores, reflecting
+the reduced per-command overhead of the leaner driver. These results motivate
+the {ref}`sec-experiments-pcie-bandwidth` experiment that follows, which
+examines how much of the available link capacity the upcie-cuda path actually
+uses.

--- a/docs/src/experiments/tool_comparison.md
+++ b/docs/src/experiments/tool_comparison.md
@@ -198,7 +198,7 @@ latency rather than paying it in full. Even with latency tracking removed,
 latency tracking also contribute to the result.
 
 At three and four threads, xnvmeperf with the SPDK backend reaches 32.8
-and 36.1 million IOPS respectively, still well below the ~62 million IOPS
+and 36.1 million IOPS respectively, still well below the 61.7 million IOPS
 device roofline. Across all thread counts, the SPDK-based tools collectively
 demonstrate that layered software overhead accumulates: removing layers yields
 meaningful gains at each step, but the combined overhead of the SPDK stack
@@ -256,7 +256,7 @@ a core assumption of the AiSIO P2P architecture.
 Notably, the upcie and upcie-cuda backends achieve approximately 37 million
 IOPS with a single CPU thread and approximately 47 million IOPS with two threads
 across 16 devices. At three threads, both backends reach the device roofline
-of ~62 million IOPS and adding a fourth thread brings no further improvement,
+of 61.7 million IOPS and adding a fourth thread brings no further improvement,
 thus confirming device saturation. The {ref}`sec-experiments-cpu-initiated`
 experiment required 8 physical cores to reach the same ceiling; the uPCIe path
 reaches it with three CPU threads, using fewer than half the cores, reflecting


### PR DESCRIPTION
This improves the documentation narrative across the experiments and
  supporting sections, tightening the red thread from the introduction through
  to the conclusion.

  ### Changes

  **Experiments index and experimental framework**
  - Added introductory paragraphs to both `experiments/index.md` and
    `experimental_framework.md` summarising what each section covers.

  **CPU-initiated I/O: Software Abstraction Overhead** (formerly "Benchmark Tool Comparison")
  - Renamed to reflect the experiment's actual purpose: measuring and overcoming
    software abstraction overhead in the I/O stack, directly addressing the
    challenge described in the introduction.
  - Extended results to cover all four CPU thread counts; added the key finding
    that uPCIe reaches the device IOPS roofline with three CPU threads, fewer
    than half the cores required by SPDK.
  - Replaced self-references and vague cross-references with proper `{ref}` links.

  **CPU-Initiated P2P I/O: PCIe Bandwidth Saturation** (formerly "PCIe Bandwidth Saturation")
  - Renamed to follow the CPU-initiated naming convention.
  - Reframed the introduction around the question of how few CPU resources and
    devices are required to saturate the PCIe link.
  - Fixed the `p2pBandwidthLatencyTest` reference value (55.98 → 56.1 GB/s) to
    match the graph.
  - Strengthened the protocol overhead finding: the 1.28× ratio holds across
    both IOPS-bound and bandwidth-bound regimes.

  **Conclusion**
  - Expanded to cover all five experiments; previously only two were described.
  - Added a synthesising paragraph connecting the resource efficiency findings
    across all experiments.
  - Added the CPU-initiated roofline as an explicit baseline reference.

  **Background**
  - Renamed "Transition to Architecture" subsection to "Summary".

  **Consistency**
  - Standardised the device IOPS roofline figure to 61.7 M IOPS throughout
    (previously stated as "~62 million" in several places).