### PR TITLE
feat(bench/compare): add fio xnvme compare workflow

### DIFF
--- a/configs/bench_fio_compare.toml
+++ b/configs/bench_fio_compare.toml
@@ -1,0 +1,3 @@
+[fio_compare]
+fio_size = "16GiB"
+output_root = "cijoe-output/artifacts/fio-compare"

--- a/configs/devices_16.toml
+++ b/configs/devices_16.toml
@@ -2,7 +2,7 @@
 fail_fast=true
 
 [xnvme.driver]
-prefix = "PCI_BLACKLIST=0000:01:00.0"
+prefix = "PCI_BLACKLIST=\"0000:01:00.0\""
 
 [[devices]]
 pci_addr = "0000:4a:00.0"

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -32,6 +32,7 @@ import logging as log
 
 from bdevperf import bdevperf_cmd, create_config as bdevperf_config
 from dcgm_helper import DcgmHelper
+from fio_xnvme import fio_xnvme_cmd
 from spdk_nvme_perf import spdk_nvme_perf_cmd
 from xnvmeperf import xnvmeperf_cmd, xnvmeperf_cuda_cmd
 
@@ -45,6 +46,7 @@ class BenchHelper():
             cfm: CpuFrequencyHelper,
             tool: str = "bdevperf",
             backend: str = "spdk",
+            fio_size: str = "16GiB",
     ):
         self.initialised = False
 
@@ -55,7 +57,7 @@ class BenchHelper():
         self.stress = False
         self.backend = backend
         self.tool = tool
-
+        self.fio_size = fio_size
         self.dcgm = DcgmHelper(cijoe) if backend == "upcie-cuda" else None
 
         self.use_thrsib = False
@@ -79,8 +81,11 @@ class BenchHelper():
                 self.bin = Path(spdk_path)  / "build" / "bin" / "spdk_nvme_perf"
         elif tool in ["xnvmeperf", "xnvmeperf-cuda"]:
             self.bin = "xnvmeperf"
+        elif tool == "fio_xnvme":
+            self.bin = "fio"
         else:
             log.error(f"Failed: Unknown tool({tool})")
+            return
 
         self.initialised = True
 
@@ -98,15 +103,15 @@ class BenchHelper():
             return err
 
         self.use_thrsib = use_thrsib
-
         return 0
 
-    def run_benchmark(self, depth: int, size: int, ndevs: int, ncpus: int, time: int, cpu_freq: float, suffix: str = "", nqueues: int = 1):
+    def run_benchmark(self, rw: str, depth: int, size: int, ndevs: int, ncpus: int, time: int, cpu_freq: float, suffix: str = "", nqueues: int = 1):
         if not self.initialised:
             log.error("Failed: benchmarker not initialised correctly")
             return 1, None
 
         is_cuda = self.tool == "xnvmeperf-cuda"
+        is_fio = self.tool == "fio_xnvme"
 
         if is_cuda:
             filename = (
@@ -114,10 +119,18 @@ class BenchHelper():
                 f"be_{self.backend}-tool_{self.tool}"
                 f"{suffix}.out"
             )
+        elif is_fio:
+            filename = (
+                f"d{ndevs}-c{ncpus}-o{size}-f_{self.fio_size}-"
+                f"rw_{rw}-q{depth}-be_{self.backend}-tool_{self.tool}-"
+                f"thrsib{1 if self.use_thrsib else 0}-"
+                f"freq_{cpu_freq}-"
+                f"stress{1 if self.stress else 0}"
+                f"{suffix}.out"
+            )
         else:
             filename = (
-                f"d{ndevs}-c{ncpus}-o{size}-q{depth}-"
-                f"be_{self.backend}-tool_{self.tool}-"
+                f"d{ndevs}-c{ncpus}-o{size}-q{depth}-be_{self.backend}-tool_{self.tool}-"
                 f"thrsib{1 if self.use_thrsib else 0}-"
                 f"freq_{cpu_freq}-"
                 f"stress{1 if self.stress else 0}"
@@ -131,15 +144,18 @@ class BenchHelper():
                 return 0, result
 
         bench_args = {
-            "iopattern": "randread",
+            "iopattern": rw,
             "qdepth": depth,
             "iosize": size,
             "runtime": time,
             "devices": [d["pci_addr"] for d in self.devices[0:ndevs]],
         }
 
-        if not is_cuda:
+        if is_cuda:
+            selected_cpus = []
+        else:
             bench_args["cpumask"] = self.cpu_masks[ncpus]
+            selected_cpus = [v[0] for v in self.cpu_pairs if int(bench_args["cpumask"], 16) & (1 << v[0])]
 
         command = f"/usr/bin/time "
 
@@ -150,10 +166,8 @@ class BenchHelper():
 
             bench_args["config_path"] = self.remote_config
             command += bdevperf_cmd(self.bin, bench_args)
-
         elif self.tool == "spdk_nvme_perf":
             command += spdk_nvme_perf_cmd(self.bin, bench_args)
-
         elif self.tool == "xnvmeperf":
             bench_args["backend"] = self.backend
             command += xnvmeperf_cmd(self.bin, bench_args)
@@ -163,14 +177,20 @@ class BenchHelper():
             bench_args["nqueues"] = nqueues
             command += xnvmeperf_cuda_cmd(self.bin, bench_args)
 
+        elif is_fio:
+            if ndevs != 1:
+                log.error("Failed: fio_xnvme currently supports exactly 1 device per benchmark point")
+                return 1, None
+
+            bench_args["backend"] = self.backend
+            bench_args["rw"] = rw
+            bench_args["fio_size"] = self.fio_size
+            cpu_list = ",".join(str(cpu) for cpu in selected_cpus)
+            command = f"taskset -c {cpu_list} {command}"
+            command += fio_xnvme_cmd(self.bin, bench_args)
         else:
             log.error(f"Unknown tool: {self.tool}")
             return -1, None
-
-        if is_cuda:
-            selected_cpus = []
-        else:
-            selected_cpus = [v[0] for v in self.cpu_pairs if int(bench_args["cpumask"], 16) & (1 << v[0])]
 
         if self.stress and (stressed_cpus := [str(x) for x in range(len(self.cpu_pairs)) if x not in selected_cpus]):
             command = "\n".join([
@@ -234,19 +254,23 @@ class BenchHelper():
         cpu_freqs = [[cpu_freqs[idx], self.cpu_pairs[idx]] for idx in selected_cpus]
 
         result = {
+            "rw": rw,
             "qdepth": depth,
             "iosize": size,
+            "fio_size": self.fio_size,
             "ndevs": ndevs,
             "ncpus": ncpus,
             "nqueues": nqueues,
+            "device_bdf": bench_args["devices"][0] if bench_args["devices"] else None,
             "cpu_usage": cpu_usage,
             "cpu_freqs": cpu_freqs,
             "fixed_freq": self.cfm.fixed_freq,
             "cpu_governor": self.cfm.governor,
-            "thr_sib": 1 if self.use_thrsib else 0,
+            "cpu_control_supported": 1 if self.cfm.cpu_control_supported else 0,
+            "thr_sib": self.use_thrsib,
             "smt": 1 if "SMT1" in suffix else 0,
             "turbo": 1 if "turbo1" in suffix else 0,
-            "stress": 1 if self.stress else 0,
+            "stress": self.stress,
             "tool": self.tool,
             "backend": self.backend,
             "iops": bench_result["total"]["iops"],
@@ -271,7 +295,6 @@ class BenchHelper():
             `(err, cpu_masks)` where a non-zero value for `err` describes that an error
             occured either while running `lscpu` or while parsing the output.
         """
-
         err, state = self.cijoe.run("lscpu -e")
         if err:
             log.error(f"Failed: lscpu -e")
@@ -284,7 +307,6 @@ class BenchHelper():
             return 1,
 
         cpu_pairs = [[int(v) for v in match.groupdict().values()] for match in matches]
-
         if use_thrsib:
             pairs = sorted(cpu_pairs, key=lambda p: p[1])
         else:
@@ -305,7 +327,6 @@ class BenchHelper():
 
         self.cpu_masks = cpu_masks
         self.cpu_pairs = cpu_pairs
-
         return 0
 
     def _parse_bench_results(self, table: str) -> Tuple[int, dict[str, list]]:
@@ -316,7 +337,6 @@ class BenchHelper():
         Returns `(err, result)`, where a non-zero value for `err` describes that the
         output did not match the expected format.
         """
-
         result = { "devices": [] }
         table_regex = None
 
@@ -326,6 +346,8 @@ class BenchHelper():
             table_regex = r"\s*(?P<name>.+?)\s*?:\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<avg_lat>[0-9.]+)\s+(?P<min_lat>[0-9.]+)\s+(?P<max_lat>[0-9.]+)"
         elif self.tool in ["xnvmeperf", "xnvmeperf-cuda"]:
             table_regex = r"\s*(?P<name>\w+):?\s+(?P<cpus>[0-9,]+)?\s+(?P<iops>[0-9.]+)\s+(?P<mibs>[0-9.]+)\s+(?P<fails>[0-9.]+)"
+        elif self.tool == "fio_xnvme":
+            return self._parse_fio_results(table)
         else:
             log.error(f"Unkown tool: {self.tool}")
             return -1, None
@@ -341,6 +363,47 @@ class BenchHelper():
 
         return 0, result
 
+    def _parse_fio_results(self, output: str) -> Tuple[int, dict[str, list]]:
+        start = output.find("{")
+        end = output.rfind("}")
+        if start < 0 or end < 0 or end <= start:
+            log.error("Failed: could not find fio JSON output")
+            return 1, None
+
+        try:
+            payload = json.loads(output[start:end + 1])
+        except json.JSONDecodeError:
+            log.error("Failed: invalid fio JSON output")
+            return 1, None
+
+        jobs = payload.get("jobs", [])
+        if not jobs:
+            log.error("Failed: fio returned no jobs")
+            return 1, None
+
+        total_iops = 0.0
+        total_mibs = 0.0
+        devices = []
+        for job in jobs:
+            metrics = job.get("read", {})
+            if not float(metrics.get("iops", 0.0)):
+                write_metrics = job.get("write", {})
+                if float(write_metrics.get("iops", 0.0)):
+                    metrics = write_metrics
+            iops = float(metrics.get("iops", 0.0))
+            mibs = float(metrics.get("bw_bytes", 0.0)) / (1024 * 1024)
+            total_iops += iops
+            total_mibs += mibs
+            devices.append({"iops": iops, "mibs": mibs})
+
+        return 0, {
+            "devices": devices,
+            "total": {
+                "iops": total_iops,
+                "mibs": total_mibs,
+            },
+        }
+
     def _parse_time_output(self, output: str) -> Tuple[int, int]:
         """
         Find the CPU usage from /usr/bin/time in from the output of /usr/bin/time.
@@ -348,7 +411,6 @@ class BenchHelper():
         Returns `(err, cpu_usage)`, where a non-zero value for `err` describes that the
         output did not match the expected format.
         """
-
         time_regex = r"(?P<user>[0-9.]+)user (?P<system>[0-9.]+)system (?P<elapsed>[0-9.:]+)elapsed (?P<cpu>[0-9.]+)%CPU .*k"
         m = search(time_regex, output)
 

--- a/scripts/bench_helper.py
+++ b/scripts/bench_helper.py
@@ -251,7 +251,10 @@ class BenchHelper():
                 log.error("Failed: DcgmHelper.stop_and_parse()")
                 return err, None
 
-        cpu_freqs = [[cpu_freqs[idx], self.cpu_pairs[idx]] for idx in selected_cpus]
+        if self.cfm.cpu_control_supported and cpu_freqs:
+            cpu_freqs = [[cpu_freqs[idx], self.cpu_pairs[idx]] for idx in selected_cpus]
+        else:
+            cpu_freqs = []
 
         result = {
             "rw": rw,

--- a/scripts/bench_runall.py
+++ b/scripts/bench_runall.py
@@ -35,11 +35,13 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--smt", type=int, default=[0,1], nargs="+", help="0 for SMT off, 1 for SMT on, [0,1] for testing both")
     parser.add_argument("--hyperthreads", type=int, default=[0,1], nargs="+", help="0 for hyper threads off, 1 for hyper threads on, [0,1] for testing both. Note that you cannot test with hyper threads if SMT is turned off")
     parser.add_argument("--stress", type=int, default=[0,1], nargs="+", help="0 for not stressing unused CPUs, 1 for stressing unused CPUs, [0,1] for testing both")
-    parser.add_argument("--time", type=int, default=10, help="Time for for bdevperf to run for each test")
+    parser.add_argument("--time", type=int, default=5, help="Time for each benchmark run")
+    parser.add_argument("--fio_size", type=str, default="16GiB", help="Working-set size for fio_xnvme")
     parser.add_argument("--results_dir", type=Path, default=None, help="Path to existing directory in which the results should be saved. Note: Already existing results will not be benchmarked again")
     parser.add_argument("--repetitions", type=int, default=5, help="The amount of times each benchmark will be repeated. The result will be average of the repetitions")
     parser.add_argument("--nqueues", type=int, default=[1], nargs="+", help="Number of queues per device (used by xnvmeperf-cuda)")
-    parser.add_argument("--tool", choices=["bdevperf", "xnvmeperf", "spdk_nvme_perf", "xnvmeperf-cuda"], default="xnvmeperf")
+    parser.add_argument("--rws", type=str, default=["randread"], nargs="+", help="List of I/O patterns to test")
+    parser.add_argument("--tool", choices=["bdevperf", "xnvmeperf", "spdk_nvme_perf", "xnvmeperf-cuda", "fio_xnvme"], default="xnvmeperf")
     parser.add_argument("--backend", type=str, default="upcie")
 
 
@@ -75,7 +77,7 @@ def main(args, cijoe: Cijoe):
         log.error("Failed: transfer_cpu_frequency_logger()")
         return err
 
-    benchmarker = BenchHelper(cijoe, bdev_configs, bdev_results, cfm, args.tool, args.backend)
+    benchmarker = BenchHelper(cijoe, bdev_configs, bdev_results, cfm, args.tool, args.backend, args.fio_size)
     if not benchmarker.initialised:
         log.error("Failed: could not initialise BenchHelper")
         return 1
@@ -95,7 +97,7 @@ def main(args, cijoe: Cijoe):
             now = time()
 
             for i in range(args.repetitions):
-                err, result = benchmarker.run_benchmark(qd, iosz, devs, 0, args.time, "N/A", f"-{i}", nq)
+                err, result = benchmarker.run_benchmark("randread", qd, iosz, devs, 0, args.time, "N/A", f"-{i}", nq)
                 if err:
                     log.error("Failed: run_benchmark()")
                     return err
@@ -124,17 +126,17 @@ def main(args, cijoe: Cijoe):
     tests = []
 
     if 0 in args.hyperthreads:
-        tests += product([0], args.turbo, args.smt, args.stress, args.cpu_freqs, test_devs, test_cpus, args.sizes, args.depths)
+        tests += product([0], args.turbo, args.smt, args.stress, args.cpu_freqs, test_devs, test_cpus, args.rws, args.sizes, args.depths)
     if 1 in args.hyperthreads:
         # shift range to match cpu hyperthreads
         test_cpus = [x for cpu in test_cpus for x in [cpu*2-1, cpu*2]]
-        tests += product([1], args.turbo, args.smt, args.stress, args.cpu_freqs, test_devs, test_cpus, args.sizes, args.depths)
+        tests += product([1], args.turbo, args.smt, args.stress, args.cpu_freqs, test_devs, test_cpus, args.rws, args.sizes, args.depths)
 
-    tests = [(ht,tu,sm,st,f,d,c,o,q) for (ht,tu,sm,st,f,d,c,o,q) in tests if not (not sm and ht)]
+    tests = [(ht,tu,sm,st,f,d,c,rw,o,q) for (ht,tu,sm,st,f,d,c,rw,o,q) in tests if not (not sm and ht)]
 
     finished, total, now = 0, len(tests), time()
 
-    for ht, tu, sm, st, freq, devs, cpus, iosz, qd in tests:
+    for ht, tu, sm, st, freq, devs, cpus, rw, iosz, qd in tests:
         err = cfm.toggle_smt(sm)
         if err:
             log.error(f"Failed: cfm.toggle_smt({sm})")
@@ -160,7 +162,7 @@ def main(args, cijoe: Cijoe):
         now = time()
 
         for i in range(args.repetitions):
-            err, result = benchmarker.run_benchmark(qd, iosz, devs, cpus, args.time, freq, f"{suffix}-{i}")
+            err, result = benchmarker.run_benchmark(rw, qd, iosz, devs, cpus, args.time, freq, f"{suffix}-{i}")
             if err:
                 log.error("Failed: run_benchmark()")
                 return err

--- a/scripts/bench_visualize.py
+++ b/scripts/bench_visualize.py
@@ -42,6 +42,11 @@ def main(args, cijoe):
         results = json.load(file)
 
     datasets = convert_to_data(results)
+    cpu_control_warning = any(
+        not row.get("cpu_control_supported", True)
+        for dataset in datasets
+        for row in dataset["data"]
+    )
 
     cuda_bandwidth = ""
     bandwidth_path = artifacts / "cuda-sample-p2p-bandwidth"
@@ -64,7 +69,13 @@ def main(args, cijoe):
     html_path.parent.mkdir(parents=True, exist_ok=True)
     with html_path.open("w") as body:
         body.write(
-            template.render({"datasets": datasets, "cuda_bandwidth": cuda_bandwidth})
+            template.render(
+                {
+                    "datasets": datasets,
+                    "cuda_bandwidth": cuda_bandwidth,
+                    "cpu_control_warning": cpu_control_warning,
+                }
+            )
         )
 
     return 0

--- a/scripts/cpu_freq_helper.py
+++ b/scripts/cpu_freq_helper.py
@@ -16,7 +16,6 @@ class CpuFrequencyHelper():
         self._smt = None
         self._turbo = None
         self.cpu_control_supported = True
-        self.cpu_control_supported = True
 
     def get_cpu_frequency_steps(self) -> Tuple[int, List[float]]:
         """
@@ -29,7 +28,6 @@ class CpuFrequencyHelper():
         err, state = self.cijoe.run('cpupower frequency-info | grep "available frequency steps"')
         if err or not state.output():
             log.error("Failed: cpupower")
-            self.cpu_control_supported = False
             return 1, None
 
         line_regex = r"\s*available frequency steps:\s+(([\d.]+ GHz,? ?)+)"
@@ -188,9 +186,20 @@ class CpuFrequencyHelper():
             log.error(f"Failed: cat {self._output}")
             return 1, None
 
-        lines = state.output().split("\n")
+        lines = [line for line in state.output().split("\n") if line.strip()]
+        if not lines:
+            self.cpu_control_supported = False
+            return 0, []
+
+        if lines[0] == "UNSUPPORTED":
+            self.cpu_control_supported = False
+            return 0, []
+
         lo, hi = int(len(lines)*0.1), int(len(lines)*0.9)
         data = [[int(f) for f in line.split()[1:]] for line in lines[lo:hi]]
+        if not data:
+            self.cpu_control_supported = False
+            return 0, []
 
         avgs = []
         for col in zip(*data):

--- a/scripts/cpu_freq_helper.py
+++ b/scripts/cpu_freq_helper.py
@@ -15,6 +15,8 @@ class CpuFrequencyHelper():
         self._steps = None
         self._smt = None
         self._turbo = None
+        self.cpu_control_supported = True
+        self.cpu_control_supported = True
 
     def get_cpu_frequency_steps(self) -> Tuple[int, List[float]]:
         """
@@ -27,6 +29,7 @@ class CpuFrequencyHelper():
         err, state = self.cijoe.run('cpupower frequency-info | grep "available frequency steps"')
         if err or not state.output():
             log.error("Failed: cpupower")
+            self.cpu_control_supported = False
             return 1, None
 
         line_regex = r"\s*available frequency steps:\s+(([\d.]+ GHz,? ?)+)"
@@ -65,8 +68,11 @@ class CpuFrequencyHelper():
 
         err, _ = self.cijoe.run(cmd)
         if err:
-            log.error("Failed: cpupower")
-            return 1
+            log.warning("cpupower unavailable or unsupported; keeping current CPU frequency policy")
+            self.cpu_control_supported = False
+            self.fixed_freq = freq
+            self.governor = gvnr
+            return 0
 
         self.fixed_freq = freq
         self.governor = gvnr
@@ -83,8 +89,11 @@ class CpuFrequencyHelper():
 
         err, _ = self.cijoe.run(f"cpupower frequency-set -g {governor} --max 4.0GHz --min 0.8GHz")
         if err:
-            log.error("Failed: cpupower")
-            return 1
+            log.warning("cpupower unavailable or unsupported; skipping fixed CPU frequency reset")
+            self.cpu_control_supported = False
+            self.fixed_freq = 0
+            self.governor = governor
+            return 0
 
         self.fixed_freq = 0
         self.governor = governor
@@ -105,16 +114,27 @@ class CpuFrequencyHelper():
             return 0
 
         no_turbo_path = "/sys/devices/system/cpu/intel_pstate/no_turbo"
-        cmd = f"echo {0 if on else 1} > {no_turbo_path}"
+        boost_path = "/sys/devices/system/cpu/cpufreq/boost"
+        cmd = None
 
         err, state = self.cijoe.run(f"ls {no_turbo_path}")
         if err or no_turbo_path != state.output().strip():
-            boost_path = "/sys/devices/system/cpu/cpufreq/boost"
+            err, state = self.cijoe.run(f"ls {boost_path}")
+            if err or boost_path != state.output().strip():
+                log.warning("Turbo control not supported on this platform; skipping turbo toggle")
+                self.cpu_control_supported = False
+                self._turbo = on
+                return 0
             cmd = f"echo {1 if on else 0} > {boost_path}"
+        else:
+            cmd = f"echo {0 if on else 1} > {no_turbo_path}"
 
         err, _ = self.cijoe.run(cmd)
         if err:
-            return err
+            log.warning("Turbo toggle failed; continuing without enforcing turbo state")
+            self.cpu_control_supported = False
+            self._turbo = on
+            return 0
 
         self._turbo = on
 

--- a/scripts/fio_compare_collect.py
+++ b/scripts/fio_compare_collect.py
@@ -1,0 +1,140 @@
+"""
+Collect FIO/xNVMe compare raw results into a single JSON document
+===============================================================
+
+Retargetable: False
+-------------------
+"""
+
+from argparse import ArgumentParser
+from collections import defaultdict
+from json import dump as json_dump, load as json_load
+from pathlib import Path
+from re import match
+import logging as log
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--results_dirs",
+        "--results-dirs",
+        nargs="+",
+        type=Path,
+        required=True,
+        help="Directories containing raw .out files for each workload",
+    )
+    parser.add_argument(
+        "--output_path",
+        "--output-path",
+        type=Path,
+        required=True,
+        help="Path for the final merged benchmark-results.json",
+    )
+
+
+def main(args, cijoe):
+    output_path = args.output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    all_results = defaultdict(list)
+    include_all = ["cpu_freqs", "iops", "mibs", "cpu_usage"]
+
+    for results_dir in args.results_dirs:
+        if not results_dir.exists():
+            log.error(f"Failed: missing raw results dir({results_dir})")
+            return 1
+
+        err = collect_results(results_dir, all_results, include_all)
+        if err:
+            return err
+
+    final_results = {
+        label: sorted(rows, key=sort_key)
+        for label, rows in all_results.items()
+    }
+
+    if output_path.exists():
+        output_path.unlink()
+
+    with output_path.open("w") as handle:
+        json_dump(final_results, handle, indent=2)
+
+    return 0
+
+
+def collect_results(results_dir: Path, all_results: dict, include_all: list[str]) -> int:
+    for path in sorted(results_dir.glob("*-0.out")):
+        label = parse_label(path.stem)
+        if label is None:
+            log.error(f"Failed parsing filename({path.stem})")
+            return 1
+
+        repeated_results = []
+        for run in sorted(results_dir.glob(f"{path.stem[:-1]}*")):
+            with run.open("r") as handle:
+                repeated_results.append(json_load(handle))
+
+        err, result = merge_dicts(repeated_results, include_all)
+        if err:
+            log.error("Failed: merge_dicts()")
+            return err
+
+        result["iops"] = avg_stddev(result["iops"])
+        result["mibs"] = avg_stddev(result["mibs"])
+        result["cpu_usage"] = avg_stddev(result["cpu_usage"])
+        all_results[label].append(result)
+
+    return 0
+
+
+def parse_label(stem: str) -> str | None:
+    regex = r".*-thrsib(?P<ht>[01])-freq_.*-stress(?P<st>[01])-SMT(?P<sm>[01])-turbo(?P<tu>[01])-\d"
+    parsed = match(regex, stem)
+    if not parsed:
+        return None
+
+    ht, st, sm, tu = map(int, parsed.groups())
+    return (
+        f"{'U' if ht else 'Not u'}sing thread siblings; "
+        f"SMT {'on' if sm else 'off'}; "
+        f"stress {'on' if st else 'off'}; "
+        f"turbo {'on' if tu else 'off'}"
+    )
+
+
+def avg_stddev(ns: list[int | float]):
+    avg = sum(ns) / len(ns)
+    stddev = (sum((x - avg) ** 2 for x in ns) / len(ns)) ** 0.5
+    return avg, stddev
+
+
+def merge_dicts(dicts: list[dict], include_all: list[str]) -> tuple[int, dict]:
+    first, merged = dicts[0], {}
+    keys = set(first.keys())
+
+    if not all(set(d.keys()) == keys for d in dicts):
+        failed = next(d for d in dicts if set(d.keys()) != keys)
+        log.error(f"Error: Expected keys of all dicts to be equal: {set(failed.keys())} != {keys}")
+        return 1, None
+
+    for key in keys:
+        if key in include_all:
+            merged[key] = [d[key] for d in dicts]
+        else:
+            if not all(d[key] == first[key] for d in dicts):
+                log.error(f"Error: Expected all values for non-excluded key({key}) to be equal")
+                return 1, None
+            merged[key] = first[key]
+
+    return 0, merged
+
+
+def sort_key(row: dict) -> tuple:
+    return (
+        row.get("device_bdf", ""),
+        row.get("rw", ""),
+        row.get("iosize", 0),
+        row.get("qdepth", 0),
+        row.get("backend", ""),
+        row.get("ncpus", 0),
+        row.get("ndevs", 0),
+    )

--- a/scripts/fio_xnvme.py
+++ b/scripts/fio_xnvme.py
@@ -1,0 +1,72 @@
+import logging as log
+from shlex import quote
+
+
+REQUIRED_KEYS = ["devices", "iosize", "qdepth", "rw", "backend", "fio_size"]
+PREFILL_REQUIRED_KEYS = ["devices", "backend", "fio_size"]
+FIO_PREFILL_BS = 131072
+FIO_PREFILL_QD = 32
+
+
+def _escape_pci_addr(pci_addr: str) -> str:
+    return pci_addr.replace(":", r"\:")
+
+
+def fio_xnvme_cmd(bin: str, args: dict) -> str:
+    if any(key not in args for key in REQUIRED_KEYS):
+        log.error(f"Failed: Missing arguments for {bin}")
+        return ""
+
+    if len(args["devices"]) != 1:
+        log.error("Failed: fio_xnvme expects exactly one device")
+        return ""
+
+    pci_addr = _escape_pci_addr(args["devices"][0])
+
+    parameters = [
+        f"{bin}",
+        "--name=job0",
+        "--thread=1",
+        "--direct=1",
+        "--group_reporting=1",
+        "--ioengine=xnvme",
+        f"--xnvme_be={args['backend']}",
+        "--xnvme_dev_nsid=1",
+        f"--rw={args['rw']}",
+        f"--bs={args['iosize']}",
+        f"--iodepth={args['qdepth']}",
+        f"--io_size={args['fio_size']}",
+        f"--filename={quote(pci_addr)}",
+        "--output-format=json",
+    ]
+    return " ".join(parameters)
+
+
+def fio_xnvme_prefill_cmd(bin: str, args: dict) -> str:
+    if any(key not in args for key in PREFILL_REQUIRED_KEYS):
+        log.error(f"Failed: Missing prefill arguments for {bin}")
+        return ""
+
+    if len(args["devices"]) != 1:
+        log.error("Failed: fio_xnvme prefill expects exactly one device")
+        return ""
+
+    pci_addr = _escape_pci_addr(args["devices"][0])
+
+    parameters = [
+        f"{bin}",
+        "--name=prefill",
+        "--thread=1",
+        "--direct=1",
+        "--group_reporting=1",
+        "--ioengine=xnvme",
+        f"--xnvme_be={args['backend']}",
+        "--xnvme_dev_nsid=1",
+        "--rw=write",
+        f"--bs={FIO_PREFILL_BS}",
+        f"--iodepth={FIO_PREFILL_QD}",
+        f"--io_size={args['fio_size']}",
+        f"--filename={quote(pci_addr)}",
+        "--output-format=json",
+    ]
+    return " ".join(parameters)

--- a/scripts/fio_xnvme_prefill.py
+++ b/scripts/fio_xnvme_prefill.py
@@ -1,0 +1,41 @@
+"""
+Run compare-specific fio/xNVMe prefill
+======================================
+
+Retargetable: True
+------------------
+"""
+
+from argparse import ArgumentParser
+import logging as log
+
+from cijoe.core.command import Cijoe
+
+from fio_xnvme import fio_xnvme_prefill_cmd
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--backend", type=str, required=True)
+    parser.add_argument("--device", type=str, required=True)
+    parser.add_argument("--fio_size", type=str, required=True)
+
+
+def main(args, cijoe: Cijoe):
+    command = fio_xnvme_prefill_cmd(
+        "fio",
+        {
+            "devices": [args.device],
+            "backend": args.backend,
+            "fio_size": args.fio_size,
+        },
+    )
+    if not command:
+        log.error("Failed: could not construct fio_xnvme prefill command")
+        return 1
+
+    err, _ = cijoe.run(command)
+    if err:
+        log.error("Failed: fio_xnvme prefill")
+        return err
+
+    return 0

--- a/scripts/fio_xnvme_trim.py
+++ b/scripts/fio_xnvme_trim.py
@@ -1,0 +1,51 @@
+"""
+Run full-device trim for fio/xNVMe compare workflows
+====================================================
+
+Retargetable: True
+------------------
+"""
+
+from argparse import ArgumentParser
+import logging as log
+import re
+
+from cijoe.core.command import Cijoe
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--backend", type=str, required=True)
+    parser.add_argument("--device", type=str, required=True)
+
+
+def _parse_namespace_info(output: str) -> tuple[str, int] | None:
+    nsid_match = re.search(r"^\s+nsid:\s+(?P<nsid>\S+)", output, re.MULTILINE)
+    nsect_match = re.search(r"^\s+nsect:\s+(?P<nsect>\S+)", output, re.MULTILINE)
+    if not nsid_match or not nsect_match:
+        return None
+
+    return nsid_match.group("nsid"), int(nsect_match.group("nsect"), 0)
+
+
+def main(args, cijoe: Cijoe):
+    err, state = cijoe.run(f"xnvme info --be {args.backend} {args.device}")
+    if err:
+        log.error("Failed: xnvme info")
+        return err
+
+    namespace = _parse_namespace_info(state.output())
+    if namespace is None:
+        log.error("Failed: could not discover nsid/nsect from xnvme info")
+        return 1
+
+    nsid, nsect = namespace
+    command = (
+        f"xnvme dsm {args.device} --be {args.backend} "
+        f"--dev-nsid {nsid} --nsid {nsid} --ad --slba 0x0 --llb {nsect - 1}"
+    )
+    err, _ = cijoe.run(command)
+    if err:
+        log.error("Failed: xnvme dsm")
+        return err
+
+    return 0

--- a/tasks/bench_fio_compare.yaml
+++ b/tasks/bench_fio_compare.yaml
@@ -1,0 +1,195 @@
+doc: |
+  Run FIO/xNVMe backend comparison benchmarks
+  ===========================================
+
+  This workflow compares the xNVMe `spdk` and `upcie` backends using fio under
+  identical benchmark parameters.
+
+  Configuration files
+  -------------------
+  Run this workflow with:
+
+    `configs/transport.toml`
+    `configs/bench_fio_compare.toml`
+    `configs/devices_*.toml`
+
+  The compare config controls the fio working-set size and the compare artifact root.
+  The device config must provide exactly one benchmark target and use
+  `xnvme.driver.prefix` to blacklist any NVMe boot device.
+
+  Output layout
+  -------------
+  A single run generates:
+
+    `<repo>/cijoe-output/artifacts/fio-compare/<bdf>/raw/<workload>/...raw .out files`
+    `<repo>/cijoe-output/artifacts/fio-compare/<bdf>/benchmark-results.json`
+    `<repo>/cijoe-output/artifacts/fio-compare/<bdf>/benchmark-results.html`
+
+  The final JSON and HTML are generated once, after all workloads complete.
+
+steps:
+- name: validate_device_config
+  run: bash -lc 'test {{ config.devices | length }} -eq 1 || { echo "bench_fio_compare requires exactly one benchmark device"; exit 1; }'
+
+- name: allocate_hugepages
+  run: |
+    sysctl -w vm.nr_hugepages=1024
+    mkdir -p /dev/hugepages
+    mountpoint -q /dev/hugepages || mount -t hugetlbfs nodev /dev/hugepages
+
+- name: prepare_spdk
+  run: |
+    {{ config.xnvme.driver.prefix }} xnvme-driver reset || true
+    modprobe uio_pci_generic
+    DRIVER_OVERRIDE=uio_pci_generic {{ config.xnvme.driver.prefix }} xnvme-driver
+
+- name: trim_before_read_spdk
+  uses: fio_xnvme_trim
+  with:
+    backend: spdk
+    device: "{{ config.devices[0].pci_addr }}"
+
+- name: prefill_readlike_spdk
+  uses: fio_xnvme_prefill
+  with:
+    backend: spdk
+    device: "{{ config.devices[0].pci_addr }}"
+    fio_size: "{{ config.fio_compare.fio_size }}"
+
+- name: run_read_spdk
+  uses: bench_runall
+  with: &bench-params-read-spdk
+    depths: [1, 4, 16, 32]
+    sizes: [4096, 16384, 65536, 131072]
+    rws: ["read"]
+    fio_size: "{{ config.fio_compare.fio_size }}"
+    numcpus_specific: [1]
+    numdevs_specific: [1]
+    cpu_freqs: ["performance"]
+    turbo: [1]
+    smt: [1]
+    hyperthreads: [0]
+    stress: [0]
+    repetitions: 3
+    results_dir: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/read"
+    tool: fio_xnvme
+    backend: spdk
+
+- name: run_randread_spdk
+  uses: bench_runall
+  with:
+    <<: *bench-params-read-spdk
+    rws: ["randread"]
+    results_dir: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/randread"
+
+- name: trim_before_write_spdk
+  uses: fio_xnvme_trim
+  with:
+    backend: spdk
+    device: "{{ config.devices[0].pci_addr }}"
+
+- name: run_write_spdk
+  uses: bench_runall
+  with: &bench-params-write-spdk
+    depths: [1, 4, 16, 32]
+    sizes: [4096, 16384, 65536, 131072]
+    rws: ["write"]
+    fio_size: "{{ config.fio_compare.fio_size }}"
+    numcpus_specific: [1]
+    numdevs_specific: [1]
+    cpu_freqs: ["performance"]
+    turbo: [1]
+    smt: [1]
+    hyperthreads: [0]
+    stress: [0]
+    repetitions: 3
+    results_dir: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/write"
+    tool: fio_xnvme
+    backend: spdk
+
+- name: trim_before_randwrite_spdk
+  uses: fio_xnvme_trim
+  with:
+    backend: spdk
+    device: "{{ config.devices[0].pci_addr }}"
+
+- name: run_randwrite_spdk
+  uses: bench_runall
+  with:
+    <<: *bench-params-write-spdk
+    rws: ["randwrite"]
+    results_dir: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/randwrite"
+
+- name: prepare_upcie
+  run: |
+    {{ config.xnvme.driver.prefix }} xnvme-driver reset || true
+    modprobe uio_pci_generic
+    DRIVER_OVERRIDE=uio_pci_generic {{ config.xnvme.driver.prefix }} xnvme-driver
+
+- name: trim_before_read_upcie
+  uses: fio_xnvme_trim
+  with:
+    backend: upcie
+    device: "{{ config.devices[0].pci_addr }}"
+
+- name: prefill_readlike_upcie
+  uses: fio_xnvme_prefill
+  with:
+    backend: upcie
+    device: "{{ config.devices[0].pci_addr }}"
+    fio_size: "{{ config.fio_compare.fio_size }}"
+
+- name: run_read_upcie
+  uses: bench_runall
+  with: &bench-params-read-upcie
+    <<: *bench-params-read-spdk
+    backend: upcie
+
+- name: run_randread_upcie
+  uses: bench_runall
+  with:
+    <<: *bench-params-read-upcie
+    rws: ["randread"]
+    results_dir: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/randread"
+
+- name: trim_before_write_upcie
+  uses: fio_xnvme_trim
+  with:
+    backend: upcie
+    device: "{{ config.devices[0].pci_addr }}"
+
+- name: run_write_upcie
+  uses: bench_runall
+  with: &bench-params-write-upcie
+    <<: *bench-params-write-spdk
+    backend: upcie
+
+- name: trim_before_randwrite_upcie
+  uses: fio_xnvme_trim
+  with:
+    backend: upcie
+    device: "{{ config.devices[0].pci_addr }}"
+
+- name: run_randwrite_upcie
+  uses: bench_runall
+  with:
+    <<: *bench-params-write-upcie
+    rws: ["randwrite"]
+    results_dir: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/randwrite"
+
+- name: collect
+  uses: fio_compare_collect
+  with:
+    results_dirs:
+      - "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/read"
+      - "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/randread"
+      - "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/write"
+      - "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/raw/randwrite"
+    output_path: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/benchmark-results.json"
+
+- name: visualize
+  uses: bench_visualize
+  with:
+    path: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/benchmark-results.json"
+    html_path: "{{ local.env.PWD }}/{{ config.fio_compare.output_root }}/{{ config.devices[0].pci_addr }}/benchmark-results.html"
+    template: benchmark-fio-compare

--- a/templates/benchmark-fio-compare.jinja2
+++ b/templates/benchmark-fio-compare.jinja2
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>FIO xNVMe Compare</title>
+<style>
+:root {
+  --bg: #ffffff;
+  --panel: #f7f9fc;
+  --ink: #1e2430;
+  --muted: #6d7481;
+  --line: #dce3ec;
+  --accent-a: #d96b2b;
+  --accent-b: #2457c5;
+  --accent-c: #0f8b6d;
+  --shadow: 0 16px 50px rgba(30, 36, 48, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Noto Sans", sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+main {
+  width: min(1320px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin: 0;
+}
+
+.hero {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+}
+
+.hero p {
+  max-width: 880px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+}
+
+.warning-banner {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid #f0c59c;
+  background: #fff4e8;
+  color: #8a4b19;
+  line-height: 1.5;
+}
+
+.warning-banner.hidden {
+  display: none;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 20px;
+}
+
+.panel {
+  padding: 20px;
+}
+
+.control-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.control-group {
+  display: grid;
+  gap: 8px;
+}
+
+.control-group label.title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.choices button {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink);
+  padding: 8px 12px;
+  font-size: 0.92rem;
+  cursor: pointer;
+}
+
+.choices button.active {
+  background: var(--ink);
+  color: white;
+  border-color: var(--ink);
+}
+
+.content {
+  display: grid;
+  gap: 20px;
+}
+
+.chart-panel {
+  padding: 24px;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.chart-header p {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.chart-wrap {
+  position: relative;
+  min-height: 420px;
+}
+
+.chart-wrap canvas {
+  width: 100%;
+  height: 420px;
+  display: block;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead th {
+  text-align: left;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  padding: 12px 10px;
+  white-space: nowrap;
+}
+
+tbody td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(215, 208, 195, 0.5);
+  white-space: nowrap;
+}
+
+tbody tr:hover {
+  background: rgba(36, 87, 197, 0.04);
+}
+
+.delta-pos {
+  color: var(--accent-c);
+  font-weight: 700;
+}
+
+.delta-neg {
+  color: #b03a2e;
+  font-weight: 700;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+@media (max-width: 980px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+</head>
+<body>
+<main>
+  <section class="hero">
+    <h1>FIO xNVMe Backend Compare</h1>
+    <p>
+      Compare `spdk` and `upcie` directly across queue depth and block size.
+      This report focuses on backend differences instead of the generic benchmark
+      framework axes.
+    </p>
+    <div class="warning-banner{% if not cpu_control_warning %} hidden{% endif %}" id="cpu-control-warning">
+      <strong>CPU control warning</strong>
+      <span>
+        Turbo, governor, or fixed-frequency control was not fully enforced on this platform.
+        Treat the reported CPU policy fields as requested settings unless the row says
+        CPU control was supported.
+      </span>
+    </div>
+  </section>
+
+  <section class="layout">
+    <aside class="panel">
+      <div class="control-grid">
+        <div class="control-group">
+          <label class="title">Environment Label</label>
+          <div class="choices" id="label-choices"></div>
+        </div>
+        <div class="control-group">
+          <label class="title">Workload</label>
+          <div class="choices" id="rw-choices"></div>
+        </div>
+        <div class="control-group">
+          <label class="title">Metric</label>
+          <div class="choices" id="metric-choices"></div>
+        </div>
+        <div class="control-group">
+          <label class="title">Block Size</label>
+          <div class="choices" id="bs-choices"></div>
+        </div>
+        <div class="control-group">
+          <label class="title">Chart</label>
+          <div class="choices" id="chartmode-choices"></div>
+        </div>
+      </div>
+    </aside>
+
+    <section class="content">
+      <article class="panel chart-panel">
+        <div class="chart-header">
+          <div>
+            <h2 id="chart-title">Queue depth comparison</h2>
+            <p id="chart-subtitle"></p>
+          </div>
+          <div class="badge">
+            <span class="legend-dot" style="background: var(--accent-a)"></span> SPDK
+            <span class="legend-dot" style="background: var(--accent-b)"></span> uPCIe
+          </div>
+        </div>
+        <div class="chart-wrap">
+          <canvas id="chart"></canvas>
+        </div>
+      </article>
+
+      <article class="panel">
+        <div class="chart-header">
+          <div>
+            <h2>Detailed Table</h2>
+            <p>Delta is relative to the SPDK value for the same block size and queue depth.</p>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Block Size</th>
+                <th>QD</th>
+                <th>SPDK IOPS</th>
+                <th>SPDK MiB/s</th>
+                <th>uPCIe IOPS</th>
+                <th>uPCIe MiB/s</th>
+                <th>Delta</th>
+              </tr>
+            </thead>
+            <tbody id="result-table"></tbody>
+          </table>
+        </div>
+      </article>
+    </section>
+  </section>
+</main>
+
+<script>
+const datasets = [
+  {%- for dataset in datasets %}
+  {
+    label: {{ dataset.label | tojson }},
+    data: [
+      {%- for d in dataset.data %}
+      {{ d | tojson }},
+      {%- endfor %}
+    ],
+  },
+  {%- endfor %}
+];
+
+const palette = {
+  spdk: "#d96b2b",
+  upcie: "#2457c5",
+  delta: "#0f8b6d",
+};
+
+const state = {
+  label: null,
+  rw: null,
+  metric: "iops",
+  bs: null,
+  chartMode: "qd",
+};
+
+const chartModes = [
+  { key: "qd", label: "By Queue Depth" },
+  { key: "bs", label: "By Block Size" },
+];
+
+const metricModes = [
+  { key: "iops", label: "IOPS" },
+  { key: "mibs", label: "MiB/s" },
+];
+
+const chartCanvas = document.getElementById("chart");
+const tableBody = document.getElementById("result-table");
+const labelChoices = document.getElementById("label-choices");
+const rwChoices = document.getElementById("rw-choices");
+const metricChoices = document.getElementById("metric-choices");
+const bsChoices = document.getElementById("bs-choices");
+const chartModeChoices = document.getElementById("chartmode-choices");
+let resizeTimer = null;
+
+function groupedDataForLabel(label) {
+  return datasets.find(entry => entry.label === label)?.data ?? [];
+}
+
+function uniq(values) {
+  return [...new Set(values)];
+}
+
+function numericSort(values) {
+  return [...values].sort((a, b) => Number(a) - Number(b));
+}
+
+function buttonSet(container, values, selected, onClick, formatter = v => v) {
+  container.innerHTML = "";
+  values.forEach(value => {
+    const button = document.createElement("button");
+    button.textContent = formatter(value);
+    if (value === selected) {
+      button.classList.add("active");
+    }
+    button.addEventListener("click", () => onClick(value));
+    container.appendChild(button);
+  });
+}
+
+function fmtNumber(value) {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 });
+}
+
+function fmtDelta(value) {
+  const text = `${value >= 0 ? "+" : ""}${value.toFixed(1)}%`;
+  const cls = value >= 0 ? "delta-pos" : "delta-neg";
+  return `<span class="${cls}">${text}</span>`;
+}
+
+function normalizeRows(rows) {
+  return rows.map(row => ({
+    ...row,
+    iops_avg: Array.isArray(row.iops) ? row.iops[0] : row.iops,
+    mibs_avg: Array.isArray(row.mibs) ? row.mibs[0] : row.mibs,
+  }));
+}
+
+function buildTableRows(rows) {
+  const grouped = new Map();
+  rows.forEach(row => {
+    const key = `${row.iosize}:${row.qdepth}`;
+    if (!grouped.has(key)) {
+      grouped.set(key, { iosize: row.iosize, qdepth: row.qdepth });
+    }
+    grouped.get(key)[row.backend] = row;
+  });
+
+  return [...grouped.values()].sort((a, b) => (
+    a.iosize - b.iosize || a.qdepth - b.qdepth
+  ));
+}
+
+function currentRows() {
+  return normalizeRows(
+    groupedDataForLabel(state.label).filter(row => row.rw === state.rw)
+  );
+}
+
+function updateSummary(rows) {
+  return rows;
+}
+
+function renderTable(rows) {
+  const tableRows = buildTableRows(rows);
+  tableBody.innerHTML = "";
+
+  tableRows.forEach(row => {
+    const spdk = row.spdk;
+    const upcie = row.upcie;
+    const base = state.metric === "iops" ? spdk?.iops_avg : spdk?.mibs_avg;
+    const probe = state.metric === "iops" ? upcie?.iops_avg : upcie?.mibs_avg;
+    const delta = base ? ((probe - base) / base) * 100 : null;
+
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${row.iosize}</td>
+      <td>${row.qdepth}</td>
+      <td>${spdk ? fmtNumber(spdk.iops_avg) : "-"}</td>
+      <td>${spdk ? fmtNumber(spdk.mibs_avg) : "-"}</td>
+      <td>${upcie ? fmtNumber(upcie.iops_avg) : "-"}</td>
+      <td>${upcie ? fmtNumber(upcie.mibs_avg) : "-"}</td>
+      <td>${delta === null || Number.isNaN(delta) ? "-" : fmtDelta(delta)}</td>
+    `;
+    tableBody.appendChild(tr);
+  });
+}
+
+function formatAxisValue(value, axis) {
+  if (axis === "bs") {
+    if (value >= 1024 * 1024) {
+      return `${(value / (1024 * 1024)).toFixed(value % (1024 * 1024) ? 1 : 0)} MiB`;
+    }
+    if (value >= 1024) {
+      return `${(value / 1024).toFixed(value % 1024 ? 1 : 0)} KiB`;
+    }
+    return `${value} B`;
+  }
+  return `${value}`;
+}
+
+function formatMetric(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "";
+  }
+  if (state.metric === "iops") {
+    return `${Math.round(value).toLocaleString()}`;
+  }
+  return value >= 100 ? `${Math.round(value).toLocaleString()}` : value.toFixed(1);
+}
+
+function setCanvasSize(canvas) {
+  const rect = canvas.getBoundingClientRect();
+  const width = Math.max(320, Math.floor(rect.width));
+  const height = Math.max(320, Math.floor(rect.height || 420));
+  const dpr = window.devicePixelRatio || 1;
+  const targetWidth = Math.round(width * dpr);
+  const targetHeight = Math.round(height * dpr);
+  if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+  }
+  const ctx = canvas.getContext("2d");
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { ctx, width, height };
+}
+
+function drawRoundedRect(ctx, x, y, w, h, r, fillStyle) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+  ctx.fillStyle = fillStyle;
+  ctx.fill();
+}
+
+function drawChart(rows) {
+  const xKey = state.chartMode === "qd" ? "qdepth" : "iosize";
+  const filterKey = state.chartMode === "qd" ? "iosize" : "qdepth";
+  const filterValue = state.chartMode === "qd" ? state.bs : 32;
+  const filtered = rows.filter(row => row[filterKey] === filterValue);
+  const xValues = numericSort(uniq(filtered.map(row => row[xKey])));
+  const metricKey = state.metric === "iops" ? "iops_avg" : "mibs_avg";
+  const title = state.chartMode === "qd" ? "Queue depth comparison" : "Block size comparison";
+  const subtitle = state.chartMode === "qd"
+    ? `${state.rw}, block size ${state.bs} bytes, metric ${state.metric.toUpperCase()}`
+    : `${state.rw}, queue depth 32, metric ${state.metric.toUpperCase()}`;
+
+  document.getElementById("chart-title").textContent = title;
+  document.getElementById("chart-subtitle").textContent = subtitle;
+
+  const { ctx, width, height } = setCanvasSize(chartCanvas);
+  ctx.clearRect(0, 0, width, height);
+
+  const margin = { top: 24, right: 20, bottom: 70, left: 68 };
+  const plot = {
+    x: margin.left,
+    y: margin.top,
+    w: width - margin.left - margin.right,
+    h: height - margin.top - margin.bottom,
+  };
+
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = "#dce3ec";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(plot.x, plot.y);
+  ctx.lineTo(plot.x, plot.y + plot.h);
+  ctx.lineTo(plot.x + plot.w, plot.y + plot.h);
+  ctx.stroke();
+
+  const series = [
+    { key: "spdk", label: "SPDK", color: palette.spdk },
+    { key: "upcie", label: "uPCIe", color: palette.upcie },
+  ];
+
+  const values = series.flatMap(seriesEntry => xValues.map(x => {
+    const row = filtered.find(entry => entry.backend === seriesEntry.key && entry[xKey] === x);
+    return row ? row[metricKey] : 0;
+  }));
+  const maxValue = Math.max(1, ...values);
+  const tickCount = 5;
+  const tickStep = maxValue / tickCount;
+
+  ctx.save();
+  ctx.fillStyle = "#6d7481";
+  ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  for (let i = 0; i <= tickCount; i += 1) {
+    const value = tickStep * i;
+    const y = plot.y + plot.h - (plot.h * i / tickCount);
+    ctx.strokeStyle = i === 0 ? "#cbd5e1" : "rgba(220, 227, 236, 0.7)";
+    ctx.beginPath();
+    ctx.moveTo(plot.x, y);
+    ctx.lineTo(plot.x + plot.w, y);
+    ctx.stroke();
+    ctx.fillText(formatMetric(value), plot.x - 10, y);
+  }
+  ctx.restore();
+
+  const groupWidth = plot.w / Math.max(xValues.length, 1);
+  const barGroupWidth = Math.min(70, groupWidth * 0.72);
+  const barWidth = barGroupWidth / series.length;
+
+  xValues.forEach((xValue, idx) => {
+    const center = plot.x + idx * groupWidth + groupWidth / 2;
+    const groupLeft = center - barGroupWidth / 2;
+    series.forEach((seriesEntry, sidx) => {
+      const row = filtered.find(entry => entry.backend === seriesEntry.key && entry[xKey] === xValue);
+      if (!row) {
+        return;
+      }
+      const value = row[metricKey] ?? 0;
+      const barHeight = (value / maxValue) * plot.h;
+      const x = groupLeft + sidx * barWidth + 2;
+      const y = plot.y + plot.h - barHeight;
+      drawRoundedRect(ctx, x, y, barWidth - 4, barHeight, 6, seriesEntry.color);
+    });
+
+    ctx.save();
+    ctx.fillStyle = "#1e2430";
+    ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    const label = formatAxisValue(xValue, xKey === "qdepth" ? "qd" : "bs");
+    ctx.fillText(label, center, plot.y + plot.h + 10);
+    ctx.restore();
+  });
+
+  ctx.save();
+  ctx.translate(18, plot.y + plot.h / 2);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillStyle = "#6d7481";
+  ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(state.metric === "iops" ? "IOPS" : "MiB/s", 0, 0);
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#6d7481";
+  ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  ctx.fillText(state.chartMode === "qd" ? "Queue Depth" : "Block Size", plot.x + plot.w / 2, height - 30);
+  ctx.restore();
+}
+
+function renderControls() {
+  const labels = datasets.map(entry => entry.label);
+  if (!state.label) {
+    state.label = labels[0];
+  }
+
+  const rows = groupedDataForLabel(state.label);
+  const workloads = uniq(rows.map(row => row.rw)).sort();
+  if (!state.rw || !workloads.includes(state.rw)) {
+    state.rw = workloads[0];
+  }
+
+  const activeRows = rows.filter(row => row.rw === state.rw);
+  const blockSizes = numericSort(uniq(activeRows.map(row => row.iosize)));
+  if (!state.bs || !blockSizes.includes(state.bs)) {
+    state.bs = blockSizes[0];
+  }
+
+  buttonSet(labelChoices, labels, state.label, value => {
+    state.label = value;
+    render();
+  });
+  buttonSet(rwChoices, workloads, state.rw, value => {
+    state.rw = value;
+    render();
+  });
+  buttonSet(metricChoices, metricModes.map(mode => mode.key), state.metric, value => {
+    state.metric = value;
+    render();
+  }, value => metricModes.find(mode => mode.key === value).label);
+  buttonSet(bsChoices, blockSizes, state.bs, value => {
+    state.bs = value;
+    render();
+  }, value => `${value}`);
+  buttonSet(chartModeChoices, chartModes.map(mode => mode.key), state.chartMode, value => {
+    state.chartMode = value;
+    render();
+  }, value => chartModes.find(mode => mode.key === value).label);
+}
+
+function render() {
+  renderControls();
+  const rows = currentRows();
+  updateSummary(rows);
+  renderTable(rows);
+  drawChart(rows);
+}
+
+window.addEventListener("resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => render(), 50);
+});
+
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add an AiSIO compare benchmark workflow for `fio + xNVMe` so we can compare
the `spdk` and `upcie` backends under the same benchmark matrix.

This series adds:
- `tasks/bench_fio_compare.yaml`
- `fio_xnvme` support in the benchmark path
- raw result collection into a single compare JSON
- compare HTML visualization
- validation and smoke coverage
- safer CPU control handling when `cpupower`, turbo sysfs, or CPU frequency
  sysfs entries are unavailable
- quoted `PCI_BLACKLIST` handling for multi-BDF device configs

## Usage

Setup order:

    cijoe --monitor -c configs/transport.toml tasks/setup_ubuntu.yaml
    cijoe --monitor -c configs/transport.toml -c configs/udmabuf_import.toml tasks/setup_udmabuf_import.yaml
    cijoe --monitor -c configs/transport.toml -c configs/nvstack.toml tasks/setup_nvstack.yaml
    cijoe --monitor -c configs/transport.toml -c configs/aisio.toml tasks/setup_aisio.yaml

Run the compare benchmark:

    cijoe --monitor \
      -c configs/transport.toml \
      -c configs/bench_fio_compare.toml \
      -c configs/devices_*.toml \
      tasks/bench_fio_compare.yaml

Results are written under `cijoe-output/artifacts/fio-compare/<bdf>/`.

Current defaults are `runtime=5s` and `fio_size=16GiB`.

## TODO

- Add a standalone `fio_xnvme` script with `add_args()` / `main()`
- Reduce duplication in `bench_fio_compare.yaml`
- Revisit platform-specific backend/device binding behavior
- Improve CPU frequency support detection on systems without standard sysfs exposure
