### PR TITLE
feat(bench/compare): add uPCIe IOMMU overhead benchmark

### DIFF
--- a/auxiliary/iommu_grub_update.py
+++ b/auxiliary/iommu_grub_update.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Update /etc/default/grub for the IOMMU overhead benchmark.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+mode = sys.argv[1]
+if mode not in ("on", "off"):
+    raise SystemExit(f"unsupported mode: {mode}")
+
+grub = Path("/etc/default/grub")
+backup = Path("/etc/default/grub.aisio-iommu-overhead.bak")
+text = grub.read_text()
+if not backup.exists():
+    backup.write_text(text)
+
+cpuinfo = Path("/proc/cpuinfo").read_text(errors="ignore").lower()
+vendor = "amd" if "authenticamd" in cpuinfo else "intel"
+token = f"{vendor}_iommu={mode}"
+
+DROP_TOKENS = {
+    "intel_iommu=off",
+    "amd_iommu=off",
+    "iommu=off",
+    "intel_iommu=on",
+    "amd_iommu=on",
+}
+
+
+def update_value(match):
+    value = match.group("value").strip()
+    tokens = [t for t in value.split() if t not in DROP_TOKENS]
+    tokens.append(token)
+    return 'GRUB_CMDLINE_LINUX_DEFAULT="' + " ".join(tokens) + '"'
+
+
+updated, count = re.subn(
+    r'^GRUB_CMDLINE_LINUX_DEFAULT="(?P<value>[^"]*)"',
+    update_value,
+    text,
+    count=1,
+    flags=re.MULTILINE,
+)
+if count == 0:
+    tokens = [token]
+    updated = (
+        text.rstrip() + '\nGRUB_CMDLINE_LINUX_DEFAULT="' + " ".join(tokens) + '"\n'
+    )
+
+grub.write_text(updated)

--- a/scripts/bench_visualize.py
+++ b/scripts/bench_visualize.py
@@ -8,6 +8,7 @@ create the HTML file, which visualizes the data.
 Retargetable: False
 -------------------
 """
+
 import json
 import jinja2
 import logging as log
@@ -18,6 +19,9 @@ from pathlib import Path
 
 def add_args(parser: ArgumentParser):
     parser.add_argument("--path", type=Path, default=None, help="Path to results.json")
+    parser.add_argument(
+        "--html_path", type=Path, default=None, help="Path to output HTML"
+    )
     parser.add_argument("--template", type=str, default="benchmark-io")
 
 
@@ -26,7 +30,9 @@ def main(args, cijoe):
 
     artifacts = Path(args.output) / "artifacts"
     json_path = args.path if args.path else artifacts / "benchmark-results.json"
-    html_path = artifacts / "benchmark-results.html"
+    html_path = (
+        args.html_path if args.html_path else artifacts / "benchmark-results.html"
+    )
 
     if not json_path.exists():
         log.error(f"Failed: could not find benchmark results on path({json_path})")
@@ -55,8 +61,11 @@ def main(args, cijoe):
     template_env = jinja2.Environment(loader=template_loader)
 
     template = template_env.get_template(f"{args.template}.jinja2")
+    html_path.parent.mkdir(parents=True, exist_ok=True)
     with html_path.open("w") as body:
-        body.write(template.render({ "datasets": datasets, "cuda_bandwidth": cuda_bandwidth }))
+        body.write(
+            template.render({"datasets": datasets, "cuda_bandwidth": cuda_bandwidth})
+        )
 
     return 0
 
@@ -83,7 +92,10 @@ def convert_to_data(all_results: dict) -> list:
     datasets = []
 
     for label, results in all_results.items():
-        data = [{k:(int(v) if isinstance(v, bool) else v) for k,v in res.items()} for res in results]
-        datasets.append({ "label": label, "data": data })
+        data = [
+            {k: (int(v) if isinstance(v, bool) else v) for k, v in res.items()}
+            for res in results
+        ]
+        datasets.append({"label": label, "data": data})
 
     return datasets

--- a/scripts/iommu_boot.py
+++ b/scripts/iommu_boot.py
@@ -1,0 +1,157 @@
+"""
+Configure and verify IOMMU boot mode
+====================================
+
+This script edits `/etc/default/grub` on the CIJOE target, regenerates the
+boot loader config, and verifies the active boot mode after reboot.
+"""
+
+import errno
+import logging as log
+import shlex
+from argparse import ArgumentParser
+from pathlib import Path
+
+from cijoe.core.resources import get_resources
+
+from iommu_common import cmdline_has_iommu_off, dmesg_indicates_iommu_enabled
+
+GRUB_UPDATE_REMOTE = "/tmp/aisio-iommu-grub-update.py"
+GRUB_UPDATE_RESOURCE = "iommu_grub_update"
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--mode",
+        choices=["set-off", "set-on", "verify-off", "verify-on"],
+        required=True,
+    )
+
+
+def quote_shell_arg(value):
+    """Return a shell-quoted string for remote command construction."""
+    return shlex.quote(str(value))
+
+
+def artifacts_path(args):
+    path = Path(args.output) / "artifacts" / "iommu-overhead"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def read_target_file(cijoe, path):
+    err, state = cijoe.run(f"cat {quote_shell_arg(path)}")
+    if err:
+        return err, None
+    return 0, state.output()
+
+
+def detect_grub_update_command(cijoe):
+    """Return the distro-appropriate command to regenerate grub config."""
+    err, _ = cijoe.run("command -v update-grub")
+    if not err:
+        return "update-grub"
+    err, _ = cijoe.run("command -v grub2-mkconfig")
+    if not err:
+        return "grub2-mkconfig -o /boot/grub2/grub.cfg"
+    return None
+
+
+def upload_grub_update_script(cijoe):
+    if not (
+        script := get_resources().get("auxiliary", {}).get(GRUB_UPDATE_RESOURCE, {})
+    ):
+        log.error("Failed retrieving the grub update script from auxiliary files")
+        return errno.ENOENT
+
+    cijoe.run(f"rm -f {quote_shell_arg(GRUB_UPDATE_REMOTE)}")
+
+    if not cijoe.put(script.path, GRUB_UPDATE_REMOTE):
+        log.error("Failed transferring grub update script from initiator to target")
+        return errno.EIO
+
+    return 0
+
+
+def set_mode(args, cijoe, mode):
+    artifacts = artifacts_path(args)
+    err, before = read_target_file(cijoe, "/etc/default/grub")
+    if err:
+        log.error(f"Failed reading /etc/default/grub: {err}")
+        return err
+    if before is not None:
+        (artifacts / f"grub-before-{mode}.txt").write_text(before)
+
+    grub_update = detect_grub_update_command(cijoe)
+    if grub_update is None:
+        log.error("No update-grub or grub2-mkconfig found on target")
+        return errno.ENOENT
+
+    err = upload_grub_update_script(cijoe)
+    if err:
+        log.error("Failed transferring grub update script")
+        return err
+
+    cmd = (
+        f"python3 {quote_shell_arg(GRUB_UPDATE_REMOTE)} "
+        f"{quote_shell_arg(mode)} && {grub_update}"
+    )
+    err, state = cijoe.run(cmd)
+    (artifacts / f"update-grub-{mode}.txt").write_text(state.output())
+    if err:
+        log.error(f"Failed updating grub for IOMMU {mode}: {state}")
+        return err
+
+    err, after = read_target_file(cijoe, "/etc/default/grub")
+    if err:
+        log.error(f"Failed reading /etc/default/grub: {err}")
+        return err
+    if after is not None:
+        (artifacts / f"grub-after-{mode}.txt").write_text(after)
+
+    return 0
+
+
+def verify_mode(args, cijoe, mode):
+    artifacts = artifacts_path(args)
+
+    err, cmdline_state = cijoe.run("cat /proc/cmdline")
+    if err:
+        log.error(f"Failed reading /proc/cmdline: {cmdline_state}")
+        return err
+    cmdline = cmdline_state.output()
+
+    err, dmesg_state = cijoe.run("dmesg | grep -i -E 'DMAR|IOMMU|AMD-Vi' || true")
+    if err:
+        log.error(f"Failed reading dmesg: {dmesg_state}")
+        return err
+    dmesg = dmesg_state.output()
+
+    (artifacts / f"iommu-verify-{mode}.txt").write_text(
+        f"=== /proc/cmdline ===\n{cmdline}\n=== dmesg ===\n{dmesg}"
+    )
+
+    off_in_cmdline = cmdline_has_iommu_off(cmdline)
+    enabled_in_dmesg = dmesg_indicates_iommu_enabled(dmesg)
+
+    if (mode == "off") != off_in_cmdline:
+        log.error(f"Expected IOMMU-{mode}, but /proc/cmdline shows the opposite")
+        return errno.EINVAL
+
+    if (mode == "on") != enabled_in_dmesg:
+        log.error(f"Expected IOMMU-{mode}, but dmesg indicates the opposite")
+        return errno.EINVAL
+
+    return 0
+
+
+def main(args, cijoe):
+    if args.mode == "set-off":
+        return set_mode(args, cijoe, "off")
+    if args.mode == "set-on":
+        return set_mode(args, cijoe, "on")
+    if args.mode == "verify-off":
+        return verify_mode(args, cijoe, "off")
+    if args.mode == "verify-on":
+        return verify_mode(args, cijoe, "on")
+    return errno.EINVAL

--- a/scripts/iommu_common.py
+++ b/scripts/iommu_common.py
@@ -1,0 +1,41 @@
+"""
+Shared helpers for IOMMU boot-mode handling
+===========================================
+"""
+
+import re
+
+IOMMU_ENABLED_PATTERNS = [
+    r"\bDMAR:\s+IOMMU enabled\b",
+    r"\bAMD-Vi:\s+IOMMU enabled\b",
+    r"\bIntel-IOMMU:\s+enabled\b",
+    r"\bIOMMU enabled\b",
+    r"\biommu:\s+Default domain type:\b",
+    r"\bAdding to iommu group\b",
+    r"\bDMAR:\s+Intel\(R\) Virtualization Technology for Directed I/O\b",
+    r"\bDMAR:\s+dmar\d+:\s+Using Queued invalidation\b",
+]
+IOMMU_DISABLED_PATTERNS = [
+    r"\bintel_iommu=off\b",
+    r"\bamd_iommu=off\b",
+    r"\biommu=off\b",
+    r"\bIOMMU disabled\b",
+    r"\bIOMMU not enabled\b",
+]
+IOMMU_OFF_CMDLINE_PATTERNS = [
+    r"\bintel_iommu=off\b",
+    r"\bamd_iommu=off\b",
+    r"\biommu=off\b",
+]
+
+
+def dmesg_indicates_iommu_enabled(text):
+    if any(re.search(pat, text, re.IGNORECASE) for pat in IOMMU_DISABLED_PATTERNS):
+        return False
+    return any(re.search(pat, text, re.IGNORECASE) for pat in IOMMU_ENABLED_PATTERNS)
+
+
+def cmdline_has_iommu_off(text):
+    return any(
+        re.search(pat, text, re.IGNORECASE) for pat in IOMMU_OFF_CMDLINE_PATTERNS
+    )

--- a/scripts/iommu_overhead.py
+++ b/scripts/iommu_overhead.py
@@ -1,0 +1,329 @@
+"""
+Collect uPCIe IOMMU overhead benchmark results
+==============================================
+
+Runs xnvmeperf and fio for one driver in the current boot configuration.
+Benchmark parameters are supplied by the task definition.
+"""
+
+import errno
+import json
+import logging as log
+import re
+import shlex
+import time
+from argparse import ArgumentParser
+from pathlib import Path
+
+from iommu_common import dmesg_indicates_iommu_enabled
+from xnvmeperf import xnvmeperf_cmd
+
+DEFAULT_REPEAT = 3
+DEFAULT_RUNTIME = 10
+DEFAULT_FIO_RAMP_TIME = 5
+DEFAULT_FIO_SIZE = "100%"
+DEFAULT_WORKLOAD_PAUSE = 5
+DEFAULT_HUGEPAGES = 1024
+DEFAULT_RWS = ["randread", "read"]
+DEFAULT_IOSIZES = [4096, 131072]
+DEFAULT_IODEPTHS = [1, 2, 4, 8, 16, 32]
+FIO_PERCENTILE_LIST = "99.9:99.99:99.999"
+TAIL_LATENCIES = {
+    "p99_9": "99.900000",
+    "p99_99": "99.990000",
+    "p99_999": "99.999000",
+}
+RW_TO_OP = {
+    "read": "read",
+    "randread": "read",
+    "write": "write",
+    "randwrite": "write",
+}
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument(
+        "--driver", choices=["uio_pci_generic", "vfio-pci"], required=True
+    )
+    parser.add_argument("--label", choices=["uio", "vfio"], required=True)
+    parser.add_argument("--repeat", type=int, default=DEFAULT_REPEAT)
+    parser.add_argument("--runtime", type=int, default=DEFAULT_RUNTIME)
+    parser.add_argument("--fio_ramp_time", type=int, default=DEFAULT_FIO_RAMP_TIME)
+    parser.add_argument("--fio_size", default=DEFAULT_FIO_SIZE)
+    parser.add_argument("--workload_pause", type=int, default=DEFAULT_WORKLOAD_PAUSE)
+    parser.add_argument("--hugepages", type=int, default=DEFAULT_HUGEPAGES)
+    parser.add_argument("--rws", nargs="+", default=DEFAULT_RWS)
+    parser.add_argument("--iosizes", type=int, nargs="+", default=DEFAULT_IOSIZES)
+    parser.add_argument("--iodepths", type=int, nargs="+", default=DEFAULT_IODEPTHS)
+
+
+def q(value):
+    return shlex.quote(str(value))
+
+
+def cpu_to_cpumask(cpu):
+    return hex(1 << int(cpu))
+
+
+def check_iommu_state(args, cijoe):
+    cmd = "cat /proc/cmdline; echo; dmesg | grep -i -E 'DMAR|IOMMU|AMD-Vi' || true"
+    err, state = cijoe.run(cmd)
+    if err:
+        log.error(f"Failed reading IOMMU state: {state}")
+        return err
+
+    enabled = dmesg_indicates_iommu_enabled(state.output())
+    expected = args.driver == "vfio-pci"
+    if enabled != expected:
+        mode = "enabled" if expected else "disabled"
+        log.error(f"{args.driver} requires IOMMU {mode}; refusing to overwrite results")
+        return errno.EINVAL
+
+    return 0
+
+
+def workload_cases(args):
+    if len(args.rws) != len(args.iosizes):
+        raise ValueError(
+            "expected rws and iosizes to have the same length, "
+            f"got {len(args.rws)} and {len(args.iosizes)}"
+        )
+
+    for rw, iosize in zip(args.rws, args.iosizes):
+        for iodepth in args.iodepths:
+            yield rw, int(iosize), int(iodepth)
+
+
+def results_path(args):
+    path = Path(args.output) / "artifacts" / "iommu-overhead" / args.label
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def run_command(cijoe, cmd):
+    err, state = cijoe.run(cmd)
+    if err:
+        log.error(f"Failed command: {state}")
+    return err, state.output()
+
+
+def bind_driver(cijoe, driver, pci_addr, mountpoint, hugepages):
+    commands = [
+        f"modprobe {q(driver)}",
+        f"umount {q(mountpoint)} || true",
+        f"sysctl -w vm.nr_hugepages={q(hugepages)}",
+        "mkdir -p /dev/hugepages",
+        "mountpoint -q /dev/hugepages || mount -t hugetlbfs nodev /dev/hugepages",
+        f"devbind --device {q(pci_addr)} --bind {q(driver)}",
+    ]
+    return run_command(cijoe, "\n".join(commands))[0]
+
+
+def reset_driver(cijoe, pci_addr):
+    err, _ = run_command(cijoe, f"devbind --device {q(pci_addr)} --bind nvme || true")
+    return err
+
+
+def build_xnvmeperf_cmd(args, pci_addr, rw, iosize, iodepth):
+    return xnvmeperf_cmd(
+        "xnvmeperf",
+        {
+            "cpumask": cpu_to_cpumask(0),
+            "qdepth": iodepth,
+            "iosize": iosize,
+            "runtime": args.runtime,
+            "iopattern": rw,
+            "backend": "upcie",
+            "devices": [pci_addr],
+        },
+    )
+
+
+def fio_cmd(args, pci_addr, rw, iosize, iodepth):
+    runtime = args.runtime
+    ramp_time = args.fio_ramp_time
+    size = args.fio_size
+    fio_device = str(pci_addr).replace(":", r"\:")
+    return " ".join(
+        [
+            "fio",
+            "--name=aisio-iommu-overhead",
+            f"--filename={q(fio_device)}",
+            "--ioengine=xnvme",
+            "--xnvme_be=upcie",
+            "--xnvme_dev_nsid=1",
+            "--thread=1",
+            "--direct=1",
+            f"--rw={q(rw)}",
+            f"--size={q(size)}",
+            f"--bs={q(iosize)}",
+            f"--iodepth={q(iodepth)}",
+            "--time_based=1",
+            f"--runtime={q(runtime)}",
+            f"--ramp_time={q(ramp_time)}",
+            "--norandommap=1",
+            "--group_reporting=1",
+            "--output-format=json",
+            f"--percentile_list={FIO_PERCENTILE_LIST}",
+            "--numjobs=1",
+            "--cpus_allowed=0",
+        ]
+    )
+
+
+def parse_xnvmeperf(output):
+    match = re.search(
+        r"^\s*Total:?\s+(?:[0-9,]+\s+)?(?P<iops>[0-9.]+)\s+"
+        r"(?P<mibs>[0-9.]+)\s+(?P<failed>[0-9.]+)",
+        output,
+        re.MULTILINE,
+    )
+    if not match:
+        raise ValueError("failed parsing xnvmeperf output")
+    return {key: float(value) for key, value in match.groupdict().items()}
+
+
+def parse_fio(output, rw):
+    data = json.loads(output)
+    job = data["jobs"][0]
+    if int(job.get("error", 0)):
+        raise ValueError(f"fio job failed with error {job['error']}")
+
+    if rw not in RW_TO_OP:
+        raise ValueError(f"unsupported rw={rw!r}; mixed workloads are not supported")
+    stats = job[RW_TO_OP[rw]]
+    percentiles = stats["clat_ns"]["percentile"]
+
+    return {
+        "iops": float(stats["iops"]),
+        "mibs": float(stats.get("bw_bytes", 0)) / (1024 * 1024),
+        "lat_ns": float(stats["lat_ns"]["mean"]),
+        "tail_lat_ns": {
+            name: float(percentiles[key]) for name, key in TAIL_LATENCIES.items()
+        },
+    }
+
+
+def result_file(path, label, runner, rw, iosize, iodepth, rep):
+    return path / (
+        f"label_{label}-runner_{runner}-rw_{rw}-iosize_{iosize}-"
+        f"iodepth_{iodepth}-rep_{rep}.json"
+    )
+
+
+def write_result(path, result):
+    with path.open("x") as jfd:
+        json.dump(result, jfd, indent=2)
+
+
+def base_result(args, runner, rw, iosize, iodepth, rep):
+    return {
+        "label": args.label,
+        "driver": args.driver,
+        "iommu": "on" if args.driver == "vfio-pci" else "off",
+        "runner": runner,
+        "rw": rw,
+        "iosize": iosize,
+        "iodepth": iodepth,
+        "repeat": rep,
+        "runtime": args.runtime,
+        "cpu": 0,
+        "cpumask": cpu_to_cpumask(0),
+        "fio_numjobs": 1,
+        "fio_cpus_allowed": "0",
+    }
+
+
+def print_progress(done, total, action):
+    print(f"{done}/{total}: {action}\033[K", end="\r", flush=True)
+
+
+def main(args, cijoe):
+    pci_addr = cijoe.getconf("filesystems.dset.pci_addr", None)
+    mountpoint = cijoe.getconf("filesystems.dset.mountpoint", "/mnt/datasets")
+    if not pci_addr:
+        log.error("Missing filesystems.dset.pci_addr in config")
+        return errno.EINVAL
+
+    err = check_iommu_state(args, cijoe)
+    if err:
+        return err
+
+    try:
+        cases = list(workload_cases(args))
+    except ValueError as err:
+        log.error(str(err))
+        return errno.EINVAL
+
+    repeat = args.repeat
+    hugepages = args.hugepages
+    workload_pause = args.workload_pause
+    out_dir = results_path(args)
+
+    err = bind_driver(cijoe, args.driver, pci_addr, mountpoint, hugepages)
+    if err:
+        return err
+
+    total = len(cases) * repeat * 2
+    done = 0
+    try:
+        for case_idx, (rw, iosize, iodepth) in enumerate(cases, start=1):
+            for rep in range(1, repeat + 1):
+                workload = (
+                    f"{args.label} {rw} iosize={iosize} iodepth={iodepth} rep={rep}"
+                )
+                path = result_file(
+                    out_dir, args.label, "xnvmeperf", rw, iosize, iodepth, rep
+                )
+
+                if path.exists():
+                    done += 1
+                    continue
+
+                print_progress(done, total, f"running xnvmeperf {workload}")
+                err, output = run_command(
+                    cijoe, build_xnvmeperf_cmd(args, pci_addr, rw, iosize, iodepth)
+                )
+                if err:
+                    return err
+                result = base_result(args, "xnvmeperf", rw, iosize, iodepth, rep)
+                result.update(parse_xnvmeperf(output))
+                if result["failed"]:
+                    log.error(f"xnvmeperf reported failed I/O: {result}")
+                    return errno.EIO
+                write_result(path, result)
+                done += 1
+
+            if workload_pause > 0 and case_idx < len(cases):
+                time.sleep(workload_pause)
+
+        for case_idx, (rw, iosize, iodepth) in enumerate(cases, start=1):
+            for rep in range(1, repeat + 1):
+                workload = (
+                    f"{args.label} {rw} iosize={iosize} iodepth={iodepth} rep={rep}"
+                )
+                path = result_file(out_dir, args.label, "fio", rw, iosize, iodepth, rep)
+
+                if path.exists():
+                    done += 1
+                    continue
+
+                print_progress(done, total, f"running fio {workload}")
+                err, output = run_command(
+                    cijoe, fio_cmd(args, pci_addr, rw, iosize, iodepth)
+                )
+                if err:
+                    return err
+                result = base_result(args, "fio", rw, iosize, iodepth, rep)
+                result.update(parse_fio(output, rw))
+                write_result(path, result)
+                done += 1
+
+            if workload_pause > 0 and case_idx < len(cases):
+                time.sleep(workload_pause)
+
+        print(f"{done}/{total}: complete")
+    finally:
+        reset_driver(cijoe, pci_addr)
+
+    return 0

--- a/scripts/iommu_overhead_combine.py
+++ b/scripts/iommu_overhead_combine.py
@@ -1,0 +1,137 @@
+"""
+Combine uPCIe IOMMU overhead benchmark results
+==============================================
+"""
+
+import errno
+import json
+import logging as log
+from argparse import ArgumentParser
+from collections import defaultdict
+from pathlib import Path
+
+
+def add_args(parser: ArgumentParser):
+    parser.add_argument("--results-dir", type=Path, default=None)
+
+
+def avg(values):
+    values = [float(value) for value in values]
+    return sum(values) / len(values)
+
+
+def pct_delta(base, value):
+    if not base:
+        return None
+    return (value - base) / base * 100.0
+
+
+def load_results(results_dir):
+    grouped = defaultdict(list)
+    for path in results_dir.glob("*/*.json"):
+        with path.open() as jfd:
+            item = json.load(jfd)
+        key = (
+            item["label"],
+            item["runner"],
+            item["rw"],
+            int(item["iosize"]),
+            int(item["iodepth"]),
+        )
+        grouped[key].append(item)
+    return grouped
+
+
+def combine_group(entries):
+    first = entries[0]
+    iops = avg(entry["iops"] for entry in entries)
+    mibs = avg(entry["mibs"] for entry in entries)
+
+    result = {
+        "label": first["label"],
+        "driver": first["driver"],
+        "iommu": first["iommu"],
+        "runner": first["runner"],
+        "rw": first["rw"],
+        "iosize": int(first["iosize"]),
+        "iodepth": int(first["iodepth"]),
+        "repeat": len(entries),
+        "runtime": first["runtime"],
+        "cpumask": first["cpumask"],
+        "iops": iops,
+        "mibs": mibs,
+    }
+
+    if first["runner"] == "fio":
+        result["lat_ns"] = avg(entry["lat_ns"] for entry in entries)
+        result["tail_lat_ns"] = {}
+        for name in ["p99_9", "p99_99", "p99_999"]:
+            result["tail_lat_ns"][name] = avg(
+                entry["tail_lat_ns"][name] for entry in entries
+            )
+
+    return result
+
+
+def pair_results(combined):
+    indexed = {}
+    for result in combined:
+        key = (result["runner"], result["rw"], result["iosize"], result["iodepth"])
+        indexed.setdefault(key, {})[result["label"]] = result
+
+    items = []
+    for key in sorted(indexed, key=lambda item: (item[1], item[2], item[0], item[3])):
+        pair = indexed[key]
+        if "uio" not in pair or "vfio" not in pair:
+            continue
+
+        runner, rw, iosize, iodepth = key
+        uio = pair["uio"]
+        vfio = pair["vfio"]
+        item = {
+            "runner": runner,
+            "rw": rw,
+            "iosize": iosize,
+            "iodepth": iodepth,
+            "uio": uio,
+            "vfio": vfio,
+            "iops_delta_pct": pct_delta(uio["iops"], vfio["iops"]),
+            "mibs_delta_pct": pct_delta(uio["mibs"], vfio["mibs"]),
+        }
+
+        if runner == "fio":
+            item["lat_delta_pct"] = pct_delta(uio["lat_ns"], vfio["lat_ns"])
+            item["tail_lat_delta_pct"] = {
+                name: pct_delta(uio["tail_lat_ns"][name], vfio["tail_lat_ns"][name])
+                for name in ["p99_9", "p99_99", "p99_999"]
+            }
+
+        items.append(item)
+
+    return items
+
+
+def main(args, cijoe):
+    artifacts = Path(args.output) / "artifacts"
+    results_dir = args.results_dir or artifacts / "iommu-overhead"
+    if not results_dir.exists():
+        log.error(f"Missing IOMMU overhead results directory: {results_dir}")
+        return errno.ENOENT
+
+    groups = load_results(results_dir)
+    if not groups:
+        log.error(f"No IOMMU overhead result JSON files found in {results_dir}")
+        return errno.ENOENT
+
+    combined = [combine_group(entries) for entries in groups.values()]
+    items = pair_results(combined)
+    if not items:
+        log.error("No matching UIO/VFIO IOMMU overhead result pairs found")
+        return errno.ENOENT
+
+    payload = {"uPCIe IOMMU Overhead": items}
+
+    with (artifacts / "benchmark-results.json").open("w") as jfd:
+        json.dump(payload, jfd, indent=2)
+
+    return 0

--- a/tasks/bench_iommu_overhead.yaml
+++ b/tasks/bench_iommu_overhead.yaml
@@ -1,0 +1,121 @@
+doc: |
+  Benchmark uPCIe IOMMU overhead
+  ==============================
+
+  This workflow automates the full uPCIe IOMMU overhead measurement:
+
+    1. boot with IOMMU disabled and collect uio_pci_generic results
+    2. boot with IOMMU enabled and collect vfio-pci results
+    3. combine both result sets and generate an HTML report
+
+  It modifies `/etc/default/grub` on the target, reboots the machine twice, and
+  waits for the CIJOE transport to return after each reboot.
+
+  The benchmark parameters live in this task so the experiment definition stays
+  self-contained.
+
+  Example:
+
+    cijoe --monitor \
+      -c configs/transport.toml \
+      -c configs/aisio.toml \
+      -c configs/datasets.toml \
+      tasks/bench_iommu_overhead.yaml
+
+  Recovery
+  --------
+  Before the first edit, the original grub config is copied to
+  `/etc/default/grub.aisio-iommu-overhead.bak` on the target. If a reboot
+  fails or the workflow is aborted in an unwanted boot state, restore with:
+
+    cp /etc/default/grub.aisio-iommu-overhead.bak /etc/default/grub \
+      && update-grub  # or: grub2-mkconfig -o /boot/grub2/grub.cfg
+
+  and reboot.
+
+steps:
+- name: set_iommu_off
+  uses: iommu_boot
+  with:
+    mode: set-off
+
+- name: reboot_iommu_off
+  run: shutdown -r now
+
+- name: wait_down_iommu_off
+  uses: core.wait_for_transport
+  with:
+    state: down
+    timeout: 60
+
+- name: wait_up_iommu_off
+  uses: core.wait_for_transport
+  with:
+    state: up
+    timeout: 300
+
+- name: verify_iommu_off
+  uses: iommu_boot
+  with:
+    mode: verify-off
+
+- name: benchmark_uio
+  uses: iommu_overhead
+  with:
+    repeat: 3
+    runtime: 10
+    fio_ramp_time: 5
+    fio_size: "100%"
+    workload_pause: 5
+    hugepages: 1024
+    rws: [randread, read]
+    iosizes: [4096, 131072]
+    iodepths: [1, 2, 4, 8, 16, 32]
+    driver: uio_pci_generic
+    label: uio
+
+- name: set_iommu_on
+  uses: iommu_boot
+  with:
+    mode: set-on
+
+- name: reboot_iommu_on
+  run: shutdown -r now
+
+- name: wait_down_iommu_on
+  uses: core.wait_for_transport
+  with:
+    state: down
+    timeout: 60
+
+- name: wait_up_iommu_on
+  uses: core.wait_for_transport
+  with:
+    state: up
+    timeout: 300
+
+- name: verify_iommu_on
+  uses: iommu_boot
+  with:
+    mode: verify-on
+
+- name: benchmark_vfio
+  uses: iommu_overhead
+  with:
+    repeat: 3
+    runtime: 10
+    fio_ramp_time: 5
+    fio_size: "100%"
+    workload_pause: 5
+    hugepages: 1024
+    rws: [randread, read]
+    iosizes: [4096, 131072]
+    iodepths: [1, 2, 4, 8, 16, 32]
+    driver: vfio-pci
+    label: vfio
+
+- name: combine
+  uses: iommu_overhead_combine
+
+- name: visualize
+  uses: iommu_overhead_visualize

--- a/tasks/bench_iommu_overhead.yaml
+++ b/tasks/bench_iommu_overhead.yaml
@@ -118,4 +118,6 @@ steps:
   uses: iommu_overhead_combine
 
 - name: visualize
-  uses: iommu_overhead_visualize
+  uses: bench_visualize
+  with:
+    template: iommu-overhead

--- a/templates/iommu-overhead.jinja2
+++ b/templates/iommu-overhead.jinja2
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>uPCIe IOMMU Overhead</title>
+<style>
+:root {
+  --bg: #ffffff;
+  --panel: #f7f9fc;
+  --ink: #1e2430;
+  --muted: #6d7481;
+  --line: #dce3ec;
+  --accent-uio: #d96b2b;
+  --accent-vfio: #2457c5;
+  --accent-delta: #0f8b6d;
+  --danger: #b03a2e;
+  --shadow: 0 16px 50px rgba(30, 36, 48, 0.08);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Noto Sans", sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+main {
+  width: min(1320px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+h1, h2, p { margin: 0; }
+
+.hero {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 0.95;
+}
+
+.hero p {
+  max-width: 920px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: 20px;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(520px, 1fr));
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.chart-card {
+  display: grid;
+  gap: 14px;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: end;
+}
+
+.chart-title {
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.chart-subtitle {
+  color: var(--muted);
+  font-size: 0.92rem;
+  margin-top: 4px;
+}
+
+.chart-wrap {
+  position: relative;
+  min-height: 300px;
+}
+
+.chart-wrap canvas {
+  width: 100%;
+  height: 300px;
+  display: block;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  display: inline-block;
+}
+
+.table-wrap { overflow-x: auto; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead th {
+  text-align: left;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  border-bottom: 1px solid var(--line);
+  padding: 12px 10px;
+  white-space: nowrap;
+}
+
+tbody td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(220, 227, 236, 0.8);
+  white-space: nowrap;
+}
+
+tbody tr:hover {
+  background: rgba(36, 87, 197, 0.04);
+}
+
+.delta-pos {
+  color: var(--accent-delta);
+  font-weight: 700;
+}
+
+.delta-neg {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.summary-panel h2 {
+  margin-bottom: 12px;
+}
+</style>
+</head>
+<body>
+<main>
+<section class="hero">
+<h1>uPCIe IOMMU Overhead</h1>
+
+<p>
+This report compares an IOMMU-off <code>uio_pci_generic</code> run against an
+IOMMU-on <code>vfio-pci</code> run. Throughput is collected with
+<code>xnvmeperf</code> and <code>fio</code>; latency is collected from
+<code>fio</code>.
+</p>
+</section>
+
+<h2>Charts</h2>
+<div class="chart-grid" id="charts"></div>
+
+<section class="panel summary-panel">
+<h2>Summary</h2>
+<div class="table-wrap">
+<table>
+<thead>
+<tr>
+  <th>Runner</th>
+  <th>RW</th>
+  <th>IO size</th>
+  <th>IO depth</th>
+  <th>UIO IOPS</th>
+  <th>VFIO IOPS</th>
+  <th>IOPS delta %</th>
+  <th>UIO MiB/s</th>
+  <th>VFIO MiB/s</th>
+  <th>MiB/s delta %</th>
+  <th>UIO mean us</th>
+  <th>VFIO mean us</th>
+  <th>Latency delta %</th>
+</tr>
+</thead>
+<tbody>
+{% macro pct(value) -%}
+{% if value is none %}N/A{% else %}{{ "%.2f"|format(value) }}{% endif %}
+{%- endmacro %}
+{% for dataset in datasets %}
+{% for item in dataset.data %}
+<tr>
+  <td>{{ item.runner }}</td>
+  <td>{{ item.rw }}</td>
+  <td>{{ item.iosize }}</td>
+  <td>{{ item.iodepth }}</td>
+  <td>{{ "%.2f"|format(item.uio.iops) }}</td>
+  <td>{{ "%.2f"|format(item.vfio.iops) }}</td>
+  <td>{{ pct(item.iops_delta_pct) }}</td>
+  <td>{{ "%.2f"|format(item.uio.mibs) }}</td>
+  <td>{{ "%.2f"|format(item.vfio.mibs) }}</td>
+  <td>{{ pct(item.mibs_delta_pct) }}</td>
+  {% if item.runner == "fio" %}
+  <td>{{ "%.2f"|format(item.uio.lat_ns / 1000.0) }}</td>
+  <td>{{ "%.2f"|format(item.vfio.lat_ns / 1000.0) }}</td>
+  <td>{{ pct(item.lat_delta_pct) }}</td>
+  {% else %}
+  <td>N/A</td>
+  <td>N/A</td>
+  <td>N/A</td>
+  {% endif %}
+</tr>
+{% endfor %}
+{% endfor %}
+</tbody>
+</table>
+</div>
+</section>
+</main>
+
+<script>
+const datasets = {{ datasets | tojson }};
+const rows = datasets.flatMap(dataset => (
+  dataset.data.map(row => ({ ...row, datasetLabel: dataset.label }))
+));
+const charts = buildCharts(rows);
+const holder = document.getElementById("charts");
+const renderedCharts = [];
+
+function pctDelta(base, value) {
+  if (!base) {
+    return null;
+  }
+  return (value - base) / base * 100.0;
+}
+
+function chartMetric(entries, title, unit, valueForSide) {
+  const chartRows = entries.map(item => {
+    const uio = valueForSide(item.uio);
+    const vfio = valueForSide(item.vfio);
+    return {
+      iodepth: item.iodepth,
+      uio,
+      vfio,
+      delta: pctDelta(uio, vfio),
+    };
+  });
+
+  return {
+    title,
+    rw: entries[0].rw,
+    iosize: entries[0].iosize,
+    unit,
+    labels: chartRows.map(row => row.iodepth),
+    uio: chartRows.map(row => row.uio),
+    vfio: chartRows.map(row => row.vfio),
+    rows: chartRows,
+  };
+}
+
+function buildCharts(items) {
+  const groups = new Map();
+  items.forEach(item => {
+    const key = `${item.runner}|${item.rw}|${item.iosize}`;
+    if (!groups.has(key)) {
+      groups.set(key, []);
+    }
+    groups.get(key).push(item);
+  });
+
+  const runnerOrder = { xnvmeperf: 0, fio: 1 };
+  const charts = [];
+  [...groups.values()]
+    .sort((a, b) => (
+      (runnerOrder[a[0].runner] ?? 99) - (runnerOrder[b[0].runner] ?? 99)
+      || a[0].rw.localeCompare(b[0].rw)
+      || Number(a[0].iosize) - Number(b[0].iosize)
+    ))
+    .forEach(entries => {
+      entries.sort((a, b) => Number(a.iodepth) - Number(b.iodepth));
+      const runner = entries[0].runner;
+      charts.push(chartMetric(entries, `${runner} IOPS`, "IOPS", side => side.iops));
+      charts.push(chartMetric(entries, `${runner} bandwidth`, "MiB/s", side => side.mibs));
+      if (runner !== "fio") {
+        return;
+      }
+      charts.push(
+        chartMetric(entries, "fio mean latency", "us", side => side.lat_ns / 1000.0)
+      );
+      [
+        ["p99_9", "fio P99.9 latency"],
+        ["p99_99", "fio P99.99 latency"],
+        ["p99_999", "fio P99.999 latency"],
+      ].forEach(([key, label]) => {
+        charts.push(
+          chartMetric(entries, label, "us", side => side.tail_lat_ns[key] / 1000.0)
+        );
+      });
+    });
+  return charts;
+}
+
+charts.forEach((chart, idx) => {
+  const card = document.createElement("section");
+  card.className = "panel chart-card";
+  const header = document.createElement("div");
+  header.className = "chart-header";
+  const titleBlock = document.createElement("div");
+  const title = document.createElement("div");
+  title.className = "chart-title";
+  title.textContent = chart.title;
+  const subtitle = document.createElement("p");
+  subtitle.className = "chart-subtitle";
+  subtitle.textContent = `${chart.rw}, ${chart.iosize} bytes`;
+  titleBlock.appendChild(title);
+  titleBlock.appendChild(subtitle);
+  const badge = document.createElement("div");
+  badge.className = "badge";
+  badge.innerHTML = `
+    <span class="legend-dot" style="background: var(--accent-uio)"></span> UIO
+    <span class="legend-dot" style="background: var(--accent-vfio)"></span> VFIO
+  `;
+  header.appendChild(titleBlock);
+  header.appendChild(badge);
+  const wrap = document.createElement("div");
+  wrap.className = "chart-wrap";
+  const canvas = document.createElement("canvas");
+  canvas.id = `chart-${idx}`;
+  wrap.appendChild(canvas);
+  const table = document.createElement("table");
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>IO depth</th>
+        <th>UIO ${chart.unit}</th>
+        <th>VFIO ${chart.unit}</th>
+        <th>Delta %</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${chart.rows.map(row => `
+        <tr>
+          <td>${row.iodepth}</td>
+          <td>${Number(row.uio).toFixed(2)}</td>
+          <td>${Number(row.vfio).toFixed(2)}</td>
+          <td>${formatDelta(row.delta)}</td>
+        </tr>
+      `).join("")}
+    </tbody>`;
+  const tableWrap = document.createElement("div");
+  tableWrap.className = "table-wrap";
+  tableWrap.appendChild(table);
+  card.appendChild(header);
+  card.appendChild(wrap);
+  card.appendChild(tableWrap);
+  holder.appendChild(card);
+  renderedCharts.push({ canvas, chart });
+});
+
+renderedCharts.forEach(({ canvas, chart }) => drawChart(canvas, chart));
+
+function formatDelta(value) {
+  if (value === null || value === undefined) {
+    return "N/A";
+  }
+  const number = Number(value);
+  if (Number.isNaN(number)) {
+    return "N/A";
+  }
+  const cls = number >= 0 ? "delta-pos" : "delta-neg";
+  const sign = number >= 0 ? "+" : "";
+  return `<span class="${cls}">${sign}${number.toFixed(2)}%</span>`;
+}
+
+function formatMetric(value, unit) {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "";
+  }
+  if (unit === "IOPS" || unit === "MiB/s") {
+    return formatCompact(value);
+  }
+  return value >= 100 ? Math.round(value).toLocaleString() : value.toFixed(2);
+}
+
+function formatCompact(value) {
+  const absValue = Math.abs(value);
+  if (absValue >= 1_000_000_000) {
+    return trimFixed(value / 1_000_000_000, 2) + "G";
+  }
+  if (absValue >= 1_000_000) {
+    return trimFixed(value / 1_000_000, 2) + "M";
+  }
+  if (absValue >= 1_000) {
+    return trimFixed(value / 1_000, 1) + "K";
+  }
+  return value >= 100 ? Math.round(value).toLocaleString() : value.toFixed(1);
+}
+
+function trimFixed(value, digits) {
+  return value.toFixed(digits).replace(/\.0+$|(\.\d*[1-9])0+$/, "$1");
+}
+
+function setCanvasSize(canvas) {
+  const rect = canvas.getBoundingClientRect();
+  const width = Math.max(320, Math.floor(rect.width));
+  const height = Math.max(280, Math.floor(rect.height || 300));
+  const dpr = window.devicePixelRatio || 1;
+  const targetWidth = Math.round(width * dpr);
+  const targetHeight = Math.round(height * dpr);
+  if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+  }
+  const ctx = canvas.getContext("2d");
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  return { ctx, width, height };
+}
+
+function drawRoundedRect(ctx, x, y, w, h, r, fillStyle) {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+  ctx.fillStyle = fillStyle;
+  ctx.fill();
+}
+
+function drawChart(canvas, chart) {
+  const { ctx, width, height } = setCanvasSize(canvas);
+  ctx.clearRect(0, 0, width, height);
+
+  const margin = { top: 20, right: 18, bottom: 52, left: 88 };
+  const plot = {
+    x: margin.left,
+    y: margin.top,
+    w: width - margin.left - margin.right,
+    h: height - margin.top - margin.bottom,
+  };
+  const values = [...chart.uio, ...chart.vfio].map(Number);
+  const maxValue = Math.max(1, ...values) * 1.08;
+  const tickCount = 4;
+
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = "#dce3ec";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(plot.x, plot.y);
+  ctx.lineTo(plot.x, plot.y + plot.h);
+  ctx.lineTo(plot.x + plot.w, plot.y + plot.h);
+  ctx.stroke();
+
+  ctx.save();
+  ctx.fillStyle = "#6d7481";
+  ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  for (let i = 0; i <= tickCount; i += 1) {
+    const value = maxValue * i / tickCount;
+    const y = plot.y + plot.h - plot.h * i / tickCount;
+    ctx.strokeStyle = i === 0 ? "#cbd5e1" : "rgba(220, 227, 236, 0.7)";
+    ctx.beginPath();
+    ctx.moveTo(plot.x, y);
+    ctx.lineTo(plot.x + plot.w, y);
+    ctx.stroke();
+    ctx.fillText(formatMetric(value, chart.unit), plot.x - 10, y);
+  }
+  ctx.restore();
+
+  const groupWidth = plot.w / Math.max(chart.labels.length, 1);
+  const groupBarWidth = Math.min(plot.w * 0.4, groupWidth * 0.72);
+  const barWidth = groupBarWidth / 2;
+
+  chart.labels.forEach((label, idx) => {
+    const center = plot.x + idx * groupWidth + groupWidth / 2;
+    const left = center - groupBarWidth / 2;
+    [
+      { value: Number(chart.uio[idx]), color: "#d96b2b" },
+      { value: Number(chart.vfio[idx]), color: "#2457c5" },
+    ].forEach((series, seriesIdx) => {
+      const barHeight = series.value / maxValue * plot.h;
+      const x = left + seriesIdx * barWidth + 2;
+      const y = plot.y + plot.h - barHeight;
+      drawRoundedRect(ctx, x, y, barWidth - 4, barHeight, 5, series.color);
+    });
+
+    ctx.save();
+    ctx.fillStyle = "#1e2430";
+    ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    ctx.fillText(`qd ${label}`, center, plot.y + plot.h + 10);
+    ctx.restore();
+  });
+
+  ctx.save();
+  ctx.translate(18, plot.y + plot.h / 2);
+  ctx.rotate(-Math.PI / 2);
+  ctx.fillStyle = "#6d7481";
+  ctx.font = "12px Segoe UI, Noto Sans, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText(chart.unit, 0, 0);
+  ctx.restore();
+}
+
+let resizeTimer = null;
+window.addEventListener("resize", () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    renderedCharts.forEach(({ canvas, chart }) => drawChart(canvas, chart));
+  }, 80);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add an AiSIO CIJOE benchmark for measuring uPCIe IOMMU overhead.

The task automates the full UIO/VFIO comparison flow by switching the target
between IOMMU-off and IOMMU-on boots, collecting benchmark results in each boot
mode, and generating an HTML report from the paired results.

## Changes

- add an IOMMU overhead benchmark config
- add a CIJOE task for the full rebooted benchmark flow
- configure and verify IOMMU boot mode through grub
- collect IOMMU-off `uio_pci_generic` results
- collect IOMMU-on `vfio-pci` results
- collect throughput with `xnvmeperf`
- collect fio throughput, mean latency, and tail latency
- combine UIO/VFIO result pairs and calculate deltas
- generate an HTML report through `bench_visualize.py`

## Usage

```bash
cijoe --monitor \
  -c configs/transport.toml \
  -c configs/aisio.toml \
  -c configs/datasets.toml \
  -c configs/iommu_overhead.toml \
  tasks/bench_iommu_overhead.yaml
```

The workflow updates /etc/default/grub on the target and reboots twice:

1. IOMMU off: collect uio_pci_generic
2. IOMMU on: collect vfio-pci
3. Combine results and render artifacts/benchmark-results.html

## Notes
- The target NVMe BDF is read from filesystems.dset.pci_addr.
- The original grub config is backed up on the target as
/etc/default/grub.aisio-iommu-overhead.bak.
- If recovery is needed, restore that file, regenerate grub config, and reboot.
- The workflow leaves the target in the final IOMMU-on boot mode.

## Result

[benchmark-results.html](https://github.com/user-attachments/files/27691984/benchmark-results.html)
