### PR TITLE
feat(aisio): bump XAL to v0.3.0 and FIL to v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,12 @@ the dataset volume, rebind the device, and allocate hugepages:
 modprobe uio_pci_generic
 umount /mnt/datasets
 devbind --device '0000:01:00.0' --bind uio_pci_generic  # pci_addr from datasets.toml
-hugepages setup --count 1024
+hugepages setup --count 5120
 ```
+
+The count must be large enough to fit the biggest batch of I/O buffers. The
+`filesize8gib` dataset drives this requirement — 5120 pages (10 GiB) is
+sufficient for the benchmarks in this suite.
 
 `devbind` and `hugepages` are installed on the target as part of `setup_aisio.yaml`.
 

--- a/configs/aisio.toml
+++ b/configs/aisio.toml
@@ -14,7 +14,7 @@ path = "/root/git/xal"
 
 [fil.repository]
 remote = "https://github.com/xnvme/fil"
-tag = "v0.2.1"
+tag = "v0.3.1"
 path = "/root/git/fil"
 
 [spdk.repository]

--- a/configs/aisio.toml
+++ b/configs/aisio.toml
@@ -9,7 +9,7 @@ path = "/root/git/xnvme"
 
 [xal.repository]
 remote = "https://github.com/xnvme/xal"
-tag = "v0.2.0"
+tag = "v0.3.0"
 path = "/root/git/xal"
 
 [fil.repository]

--- a/scripts/filperf.py
+++ b/scripts/filperf.py
@@ -36,7 +36,7 @@ def get_opts(args, cijoe, backend):
     elif backend == "cufile":
         if mountpoint:
             out += f"--mnt {mountpoint} "
-    elif backend in ("aisio-cpu", "aisio-gpu"):
+    elif backend in ("aisio-cpu", "aisio-gpu", "aisio-p2p"):
         if args.max_file_size:
             out += f"--max-file-size {args.max_file_size} "
         if backend == "aisio-gpu":

--- a/scripts/filperf.py
+++ b/scripts/filperf.py
@@ -20,6 +20,7 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--bin", type=str, default="filperf")
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--batches", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=0)
     parser.add_argument("--gpu_nqueues", type=int, default=6)
     parser.add_argument("--queue_depth", type=int, default=1024)
     parser.add_argument("--max_file_size", type=int, default=0)
@@ -49,7 +50,8 @@ def main(args, cijoe):
     prefix = "echo 3 > /proc/sys/vm/drop_caches;"
 
     opts = get_opts(args, cijoe, args.backend)
-    cmd = f"{prefix} {args.bin} {args.device} --data-dir {args.dataset} --batches {args.batches} --batch-size {args.batch_size} --backend {args.backend} {opts}"
+    warmup_opt = f"--warmup {args.warmup} " if args.warmup else ""
+    cmd = f"{prefix} {args.bin} {args.device} --data-dir {args.dataset} --batches {args.batches} --batch-size {args.batch_size} --backend {args.backend} {opts}{warmup_opt}--summary"
     for _ in range(args.repetitions):
         err, _ = cijoe.run(cmd)
     if err:

--- a/scripts/filperf.py
+++ b/scripts/filperf.py
@@ -21,6 +21,8 @@ def add_args(parser: ArgumentParser):
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--batches", type=int, default=1)
     parser.add_argument("--gpu_nqueues", type=int, default=6)
+    parser.add_argument("--queue_depth", type=int, default=1024)
+    parser.add_argument("--max_file_size", type=int, default=0)
     parser.add_argument("--repetitions", type=int, default=5)
 
 
@@ -31,8 +33,15 @@ def get_opts(args, cijoe, backend):
         if mountpoint:
             out += f"--mnt {mountpoint} "
         out += "--buffered "
-    elif backend == "aisio":
-        out += f"--gpu-nqueues {args.gpu_nqueues} "
+    elif backend == "cufile":
+        if mountpoint:
+            out += f"--mnt {mountpoint} "
+    elif backend in ("aisio-cpu", "aisio-gpu"):
+        if args.max_file_size:
+            out += f"--max-file-size {args.max_file_size} "
+        if backend == "aisio-gpu":
+            out += f"--gpu-nqueues {args.gpu_nqueues} "
+        out += f"--queue-depth {args.queue_depth} "
     return out
 
 

--- a/tasks/bench_aisio.yaml
+++ b/tasks/bench_aisio.yaml
@@ -20,6 +20,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 26
     batches: 1
+    warmup: 1
     max_file_size: "{{ config.datasets.tiktokish.filesize_max }}"
     repetitions: 1
 
@@ -31,6 +32,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 26
     batches: 1
+    warmup: 1
     max_file_size: "{{ config.datasets.tiktokish.filesize_max }}"
     gpu_nqueues: 4
     queue_depth: 512
@@ -44,6 +46,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 26
     batches: 1
+    warmup: 1
     max_file_size: "{{ config.datasets.tiktokish.filesize_max }}"
     repetitions: 1
 
@@ -55,6 +58,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1024
     batches: 300
+    warmup: 1
     max_file_size: "{{ config.datasets.imagenetish.filesize_max }}"
     repetitions: 1
 
@@ -66,6 +70,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1024
     batches: 300
+    warmup: 1
     max_file_size: "{{ config.datasets.imagenetish.filesize_max }}"
     gpu_nqueues: 4
     queue_depth: 512
@@ -79,6 +84,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1024
     batches: 300
+    warmup: 1
     max_file_size: "{{ config.datasets.imagenetish.filesize_max }}"
     repetitions: 1
 
@@ -90,6 +96,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1
     batches: 10
+    warmup: 1
     max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
     repetitions: 1
 
@@ -101,6 +108,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1
     batches: 10
+    warmup: 1
     max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
     gpu_nqueues: 4
     queue_depth: 512
@@ -114,6 +122,7 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1
     batches: 10
+    warmup: 1
     max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
     repetitions: 1
 

--- a/tasks/bench_aisio.yaml
+++ b/tasks/bench_aisio.yaml
@@ -3,8 +3,7 @@ doc: |
   ============================================
 
   The benchmarks include:
-  - reading 2 datasets: tiktokish, imagenetish (filesize8gib is skipped as
-    individual files exceed the 256MB xNVMe uPCIe HOSTMEM heap limit),
+  - reading 3 datasets: tiktokish, imagenetish, filesize8gib
   - performing synthetic randread benchmarks for: upcie, upcie-cuda
 
   See README.md for device binding and hugepage setup required before running
@@ -21,6 +20,20 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 26
     batches: 1
+    max_file_size: "{{ config.datasets.tiktokish.filesize_max }}"
+    repetitions: 1
+
+- name: tiktokish-gpu
+  uses: filperf
+  with:
+    backend: "aisio-gpu"
+    dataset: "tiktokish"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 26
+    batches: 1
+    max_file_size: "{{ config.datasets.tiktokish.filesize_max }}"
+    gpu_nqueues: 4
+    queue_depth: 512
     repetitions: 1
 
 - name: imagenetish
@@ -31,6 +44,44 @@ steps:
     device: "{{ config.filesystems.dset.pci_addr }}"
     batch_size: 1024
     batches: 300
+    max_file_size: "{{ config.datasets.imagenetish.filesize_max }}"
+    repetitions: 1
+
+- name: imagenetish-gpu
+  uses: filperf
+  with:
+    backend: "aisio-gpu"
+    dataset: "imagenetish"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 1024
+    batches: 300
+    max_file_size: "{{ config.datasets.imagenetish.filesize_max }}"
+    gpu_nqueues: 4
+    queue_depth: 512
+    repetitions: 1
+
+- name: filesize8gib
+  uses: filperf
+  with:
+    backend: "aisio-cpu"
+    dataset: "filesize8gib"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 1
+    batches: 10
+    max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
+    repetitions: 1
+
+- name: filesize8gib-gpu
+  uses: filperf
+  with:
+    backend: "aisio-gpu"
+    dataset: "filesize8gib"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 1
+    batches: 10
+    max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
+    gpu_nqueues: 4
+    queue_depth: 512
     repetitions: 1
 
 - name: cpu-initiated

--- a/tasks/bench_aisio.yaml
+++ b/tasks/bench_aisio.yaml
@@ -36,6 +36,17 @@ steps:
     queue_depth: 512
     repetitions: 1
 
+- name: tiktokish-p2p
+  uses: filperf
+  with:
+    backend: "aisio-p2p"
+    dataset: "tiktokish"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 26
+    batches: 1
+    max_file_size: "{{ config.datasets.tiktokish.filesize_max }}"
+    repetitions: 1
+
 - name: imagenetish
   uses: filperf
   with:
@@ -60,6 +71,17 @@ steps:
     queue_depth: 512
     repetitions: 1
 
+- name: imagenetish-p2p
+  uses: filperf
+  with:
+    backend: "aisio-p2p"
+    dataset: "imagenetish"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 1024
+    batches: 300
+    max_file_size: "{{ config.datasets.imagenetish.filesize_max }}"
+    repetitions: 1
+
 - name: filesize8gib
   uses: filperf
   with:
@@ -82,6 +104,17 @@ steps:
     max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
     gpu_nqueues: 4
     queue_depth: 512
+    repetitions: 1
+
+- name: filesize8gib-p2p
+  uses: filperf
+  with:
+    backend: "aisio-p2p"
+    dataset: "filesize8gib"
+    device: "{{ config.filesystems.dset.pci_addr }}"
+    batch_size: 1
+    batches: 10
+    max_file_size: "{{ config.datasets.filesize8gib.filesize_max }}"
     repetitions: 1
 
 - name: cpu-initiated

--- a/tasks/setup_aisio.yaml
+++ b/tasks/setup_aisio.yaml
@@ -45,7 +45,7 @@ steps:
 
 - name: xal
   run: |
-    apt-get install -fy xfslibs-dev
+    apt-get install -fy xfslibs-dev clang libbpf-dev libelf-dev zlib1g-dev
     rm -r "{{ config.xal.repository.path }}/builddir" || true
     mkdir -p "{{ config.xal.repository.path }}/builddir"
     cd "{{ config.xal.repository.path }}"; meson setup builddir

--- a/tasks/setup_dataset.yaml
+++ b/tasks/setup_dataset.yaml
@@ -19,7 +19,6 @@ steps:
     mkfs.xfs -f -m reflink=0 {{ config.filesystems.dset.bdev }}
     mkdir -p {{ config.filesystems.dset.mountpoint }}
     mount -o noatime {{ config.filesystems.dset.bdev }} {{ config.filesystems.dset.mountpoint }}
-    mkdir -p {{ config.filesystems.dset.mountpoint }}/gds
     df -h
 
 - name: filesize8gib_generate

--- a/tasks/setup_udmabuf_import.yaml
+++ b/tasks/setup_udmabuf_import.yaml
@@ -37,7 +37,7 @@ steps:
 - name: install_dependencies
   run: |
     apt-get -qy update
-    DEBIAN_FRONTEND=noninteractive apt-get -qy install {{ config.linux.source.pkg }} build-essential fakeroot debhelper bison flex libssl-dev libelf-dev libdw-dev libncurses-dev libpci-dev bc dwarves rsync kmod cpio
+    DEBIAN_FRONTEND=noninteractive apt-get -qy install {{ config.linux.source.pkg }} build-essential fakeroot debhelper bison flex libssl-dev libelf-dev libdw-dev libncurses-dev libpci-dev bc dwarves rsync kmod cpio clang llvm
 
 - name: extract
   run: |
@@ -57,7 +57,7 @@ steps:
 - name: configure
   run: |
     cp /boot/config-$(uname -r) /usr/src/ksrc/.config
-    cd /usr/src/ksrc && scripts/config --disable DEBUG_INFO --disable MODULE_SIG --disable LOCALVERSION_AUTO --set-str LOCALVERSION "-dmabuf" --set-str SYSTEM_TRUSTED_KEYS "" --set-str SYSTEM_REVOCATION_KEYS ""
+    cd /usr/src/ksrc && scripts/config --disable DEBUG_INFO_NONE --enable DEBUG_INFO_DWARF4 --disable DEBUG_INFO_REDUCED --enable DEBUG_INFO_BTF --disable MODULE_SIG --disable LOCALVERSION_AUTO --set-str LOCALVERSION "-dmabuf" --set-str SYSTEM_TRUSTED_KEYS "" --set-str SYSTEM_REVOCATION_KEYS ""
     make -C /usr/src/ksrc olddefconfig
 
 - name: package
@@ -73,12 +73,12 @@ steps:
     # compile out-of-tree modules against (e.g. the NVIDIA driver); then the
     # image. linux-libc-dev carries the patched userspace UAPI, so
     # /usr/include/linux/udmabuf.h gains the importer ioctls (UDMABUF_ATTACH /
-    # UDMABUF_GET_MAP) that user-space DMA-buf importers build against. Tolerate
-    # a kernel-incompatible DKMS module; guarantee a bootable image and grub
-    # entry regardless.
+    # UDMABUF_GET_MAP) that user-space DMA-buf importers build against. Skip the
+    # -dbg package emitted by DEBUG_INFO/BTF. Tolerate a kernel-incompatible DKMS
+    # module; guarantee a bootable image and grub entry regardless.
     dpkg -i /usr/src/linux-headers-*dmabuf*.deb || true
     dpkg -i /usr/src/linux-libc-dev_*.deb || true
-    dpkg -i /usr/src/linux-image-*dmabuf*.deb || true
+    dpkg -i $(ls /usr/src/linux-image-*dmabuf*.deb | grep -v -- '-dbg') || true
     kver=$(make -C /usr/src/ksrc -s kernelrelease) && { update-initramfs -c -k "$kver" 2>/dev/null || update-initramfs -u -k "$kver"; }
     update-grub
 
@@ -100,3 +100,7 @@ steps:
 - name: install_cpupower
   run: |
     make -C /usr/src/ksrc tools/cpupower_install prefix=/usr libdir=/usr/lib
+
+- name: install_bpftool
+  run: |
+    make -C /usr/src/ksrc tools/bpftool_install prefix=/usr


### PR DESCRIPTION
## Summary

Upgrades the AiSIO stack to xal v0.3.0 / fil v0.3.1 and expands the benchmark
suite to exercise the new CPU, GPU, and peer-to-peer I/O paths across all three
datasets.

## Toolchain

- Bump xal to v0.3.0 and fil to v0.3.1.
- xal v0.3.0 relies on BPF, so the build now needs a BTF-enabled kernel and
  `bpftool`:
  - Kernel config switches from a debug-info-free build to DWARF4 + `DEBUG_INFO_BTF`,
    with the resulting `-dbg` image package filtered out at install time.
  - `bpftool` is built and installed from the kernel source tree.
  - `clang`, `llvm`, and libbpf/libelf/zlib dev packages are added to the xal
    and kernel build steps.

## Benchmarks

- `filperf.py` gains explicit per-backend handling for `cufile` and the new
  `aisio-cpu` / `aisio-gpu` / `aisio-p2p` backends, plus `--warmup`,
  `--queue-depth`, and `--max-file-size` options, and emits `--summary`.
- `bench_aisio` now runs CPU, GPU, and P2P variants for `tiktokish`,
  `imagenetish`, and `filesize8gib`. The `filesize8gib` dataset is no longer
  skipped — capping per-file size lets it fit within the buffer budget.
- README bumps the hugepage count to 5120 (10 GiB) so the largest batch of I/O
  buffers fits, with a note on why.

## Cleanup

- Drop the unused `gds` subdirectory from dataset setup.