### PR TITLE
Fix AiSIO provisioning on Ubuntu 26.04

### DIFF
--- a/configs/aisio.toml
+++ b/configs/aisio.toml
@@ -9,7 +9,7 @@ path = "/root/git/xnvme"
 
 [xal.repository]
 remote = "https://github.com/xnvme/xal"
-tag = "v0.3.0"
+tag = "v0.3.1"
 path = "/root/git/xal"
 
 [fil.repository]

--- a/configs/aisio.toml
+++ b/configs/aisio.toml
@@ -4,7 +4,7 @@ version = "resolute"
 
 [xnvme.repository]
 remote = "https://github.com/xnvme/xnvme"
-branch = "next"
+branch = "main"
 path = "/root/git/xnvme"
 
 [xal.repository]

--- a/scripts/cuda_p2p_sample.py
+++ b/scripts/cuda_p2p_sample.py
@@ -27,7 +27,7 @@ def main(args, cijoe: Cijoe):
   # knob is required (the old nvstack.toml key is gone).
   sample_path = cijoe.getconf("nvidia.cuda.samples.path", "/root/git/cuda-samples")
 
-  bin = Path(sample_path) / "build" / "Samples" / "5_Domain_Specific" / "p2pBandwidthLatencyTest" / "p2pBandwidthLatencyTest"
+  bin = Path(sample_path) / "build" / "cpp" / "5_Domain_Specific" / "p2pBandwidthLatencyTest" / "p2pBandwidthLatencyTest"
 
   err, state = cijoe.run(f"{bin}")
   if err:

--- a/tasks/setup_aisio.yaml
+++ b/tasks/setup_aisio.yaml
@@ -23,17 +23,6 @@ steps:
     pipx install hugepages
     pipx ensurepath
 
-- name: gcc
-  run: |
-    apt-get -fy install gcc-12 g++-12
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120 --slave /usr/bin/g++ g++ /usr/bin/g++-12
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 --slave /usr/bin/g++ g++ /usr/bin/g++-13
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 120 --slave /usr/bin/g++ g++ /usr/bin/g++-12
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 --slave /usr/bin/g++ g++ /usr/bin/g++-13
-    update-alternatives --set gcc /usr/bin/gcc-12
-    gcc --version
-    g++ --version
-
 - name: xnvme
   run: |
     chmod +x "{{ config.xnvme.repository.path }}/toolbox/pkgs/{{ config.os.distro }}-{{ config.os.version }}.sh"

--- a/tasks/setup_nvstack.yaml
+++ b/tasks/setup_nvstack.yaml
@@ -91,4 +91,4 @@ steps:
     export PATH=/usr/local/cuda/bin:$PATH
     cmake -S /root/git/cuda-samples -B /root/git/cuda-samples/build
     cmake --build /root/git/cuda-samples/build --target p2pBandwidthLatencyTest -j "$(nproc)"
-    ls -l /root/git/cuda-samples/build/Samples/5_Domain_Specific/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest
+    ls -l /root/git/cuda-samples/build/cpp/5_Domain_Specific/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest

--- a/tasks/setup_udmabuf_import.yaml
+++ b/tasks/setup_udmabuf_import.yaml
@@ -103,4 +103,4 @@ steps:
 
 - name: install_bpftool
   run: |
-    make -C /usr/src/ksrc tools/bpftool_install prefix=/usr
+    make -C /usr/src/ksrc/tools/bpf/bpftool install prefix=/usr


### PR DESCRIPTION
Provisioning a freshly-installed Ubuntu 26.04 host end-to-end surfaced
several breakages in the setup workflows. This PR fixes them so a clean machine
gets through `setup_udmabuf_import` → `setup_nvstack` → `setup_aisio`.

Verified on a fresh 26.04 host (Linux 7.0.6-dmabuf, H100, CUDA 13.3): the
full buildable stack (**xNVMe, xal, fio, and SPDK**) compiles and installs
cleanly with the distro-default gcc-15.

## Changes

- **Track xNVMe `main` instead of `next`.** Checking out `next` fails and
  aborts source fetch before anything builds.
- **Install bpftool via its own make target.** The kernel top-level Makefile
  has no `tools/bpftool_install` target on Linux 7.0, so the step aborted.
  Use `make -C tools/bpf/bpftool install`.
- **Locate `p2pBandwidthLatencyTest` under `build/cpp`.** Recent cuda-samples
  moved binaries from `build/Samples/...` to `build/cpp/...`; updates the
  nvstack build check and `cuda_p2p_sample.py`.
- **Drop the gcc-12 pin.** gcc-15 builds the whole stack cleanly. The step
  also referenced a nonexistent `gcc-13` alternative (which aborted setup),
  and mixing gcc-12 with gcc-15-built components caused LTO version
  mismatches at link.
- **Bump xal to v0.3.1**, pulling in the `__packed` build fix
  ([xnvme/xal#37](https://github.com/xnvme/xal/pull/37)) needed to link `libxal` on modern toolchains.


## Known issue — needs an upstream xNVMe fix (out of scope here)

`fil` does not yet build: compiling its CUDA path (`src/gpu_io.cu` →
`libxnvme_cuda.h`) fails with

    fatal error: upcie/nvme/nvme_command.h: No such file or directory

The uPCIe headers are not exported/installed by xNVMe, so downstream
consumers like `fil` can't include them. This is a known issue: [xnvme/xnvme#674](https://github.com/xnvme/xnvme/issues/674). This must be fixed upstream in
xNVMe, it is not addressable in this repo.