### PR TITLE
Re-run the P2P experiments and report what device-initiated I/O costs the GPU

### DIFF
--- a/artifacts/device-initiated-iosize.tar.gz
+++ b/artifacts/device-initiated-iosize.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0822d04366165f32612fc9f215de142c8d830e373302ab3473309bede9e35de6
-size 4815110
+oid sha256:7cce992764f1a8f820b7f60292bd4fef0b93dee18be79223cbb8caf4913255f2
+size 4409292

--- a/artifacts/device-initiated-qdepth.tar.gz
+++ b/artifacts/device-initiated-qdepth.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0be92ce7dfbcaddcd2e5db28f001a69ced2ddff9431dbe4b258ecde95a5ba3de
-size 4139652
+oid sha256:6156f600e37df3bf429ba1ae9ea86eed475c6ebe5375c39e659767ff825453e9
+size 3530706

--- a/artifacts/pcie-bandwidth-saturation.tar.gz
+++ b/artifacts/pcie-bandwidth-saturation.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11841f22c2c59c7393e0e5b8fa39bf0d123fe1cec2b14fa4078bce716fbedb24
-size 223022
+oid sha256:71671c0015be8c95666a002d24d9d53cbd6c6bafe1acf376fe1b779d076b8cf9
+size 221630

--- a/docs/src/environments.md
+++ b/docs/src/environments.md
@@ -42,7 +42,7 @@ system provides 2 TiB of host memory.
 | Motherboard | Dell PowerEdge R760                |
 | CPU         | 2x Intel® Xeon® Gold 6442Y         |
 | Memory      | 32x 64GiB Samsung DDR5 4800MHz     |
-| GPU         | 2x NVIDIA H100 80GB                |
+| GPU         | 1x NVIDIA H100 PCIe 80GB           |
 | Storage     | 16x Samsung SSD PM1753 32TB        |
 
 (sec-env-gpu-workstation)=

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -92,6 +92,32 @@ devbind --device '<pci_addr>' --bind uio_pci_generic
 hugepages setup --count 1024
 ```
 
+(sec-device-fill-state)=
+#### Device Fill State
+
+Every namespace is formatted before synthetic benchmarks are run, which leaves all
+logical blocks deallocated. Reads of deallocated blocks are served by the
+controller without media access resulting in a synthetically low latency.
+The figures this produces may therefore exceed those seen in real-world,
+data-bearing workloads. They are an upper bound on what the I/O path can drive,
+and are to be read as a measure of system overhead and scalability rather than
+as an indicator of application-level storage performance.
+
+The format is a manual step rather than a workflow step, because it only has to
+be done once: every synthetic benchmark issues ``randread`` exclusively, so none
+of them write to the devices and the state established by the format survives
+across runs. Formatting goes through the kernel NVMe driver, so it precedes the
+binding to ``uio_pci_generic`` above and each device is rebound afterwards:
+
+```
+devbind --device '<pci_addr>' --bind nvme
+nvme format /dev/<ns> --force
+devbind --device '<pci_addr>' --bind uio_pci_generic
+```
+
+
+#### Running the Workflows
+
 The benchmark workflows are parameterised by editing the ``run`` step in
 the respective task file. The keys under ``with`` correspond to
 independent variables. ``numcpus_range`` and ``numdevs_range`` are

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -178,9 +178,15 @@ counters via DCGM and a reference PCIe bandwidth measurement from
 ``nvbandwidth``. Described in detail in
 {ref}`sec-experiments-pcie-bandwidth`.
 
-The ``nvbandwidth`` reference binary is built by
-``setup_nvstack.yaml`` at a fixed path, and DCGM fields default in the
-collector, so no extra config is required.
+``nvbandwidth`` copies from host memory into GPU memory across the PCIe link of
+the GPU given by ``dcgm.gpu``, the same link the NVMe devices transfer over under
+P2P, which measures the peak bandwidth that link sustains. The value recorded is
+its ``host_to_device_memcpy_ce`` result.
+
+This and ``bench_cuda_iosize.yaml``, measure the PCIe bandwidth with
+``nvbandwidth`` as a step of their own run rather than carrying a fixed value
+across experiments. As such, the experiments can quote figures that differ
+slightly in the last digit.
 
 ```
 cijoe --monitor \
@@ -196,9 +202,6 @@ Characterizes the minimum CUDA thread count needed to saturate the PCIe link
 under device-initiated I/O, using **xnvmeperf** with the ``cuda-run`` subcommand
 and the **upcie-cuda** backend, with queue depth as the secondary variable.
 Described in detail in {ref}`sec-experiments-cuda-iosize`.
-
-The ``nvbandwidth`` reference binary is built by
-``setup_nvstack.yaml`` at a fixed path, so no extra config is required.
 
 ```
 cijoe --monitor \

--- a/docs/src/experimental_framework.md
+++ b/docs/src/experimental_framework.md
@@ -115,6 +115,35 @@ nvme format /dev/<ns> --force
 devbind --device '<pci_addr>' --bind uio_pci_generic
 ```
 
+(sec-dcgm-sampling)=
+#### GPU Telemetry
+
+The benchmarks that transfer into GPU memory collect GPU telemetry with
+``dcgmi dmon`` alongside what the benchmark tool itself reports. The fields are
+those of the [DCGM feature
+overview](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/feature-overview.html),
+which defines each of them; every experiment lists the ones it reports.
+
+Fields are sampled every 100 ms and reported as mean/p95/min/max over the
+samples in which the devices were transferring. A sample counts as transferring
+when the PCIe receive traffic (field 1010) exceeds 100 MB/s or the graphics
+engine (field 1001) is more than 1% active. The monitoring window also spans
+process startup and teardown, whose duration varies with the configuration under
+test, so a mean over the whole window would describe the length of the setup as
+much as the workload. The share of the window that qualified is recorded
+alongside the statistics.
+
+The engine fields report what is running on the GPU: SM activity (1002) how much
+of the device has a warp resident on it, warp slot occupancy (1003) how much of
+the warp capacity of a multiprocessor is taken, and DRAM_ACTIVE (1005) how much
+of the GPU memory bandwidth is in use.
+
+The clocks (fields 100 and 101), the throttle reason bits (112), the PCIe replay
+counter (202) and the link generation and width (237/238) are collected as
+guards on whether runs are comparable: the activity fields are fractions of
+cycles, so a run measured at a sagging clock cannot be held against one measured
+at boost, and a downtrained or retransmitting link changes the bandwidth there
+is to reach.
 
 #### Running the Workflows
 

--- a/docs/src/experiments/cpu_initiated.md
+++ b/docs/src/experiments/cpu_initiated.md
@@ -115,30 +115,15 @@ not, the first and last 10% of the reported cpu frequencies are discarded.
 ## Environment
 
 The benchmarks were run on the {ref}`sec-env-hpc-server`. All block devices were
-empty and bound to the uio-pci-generic user space driver. The CPU used the
-intel_cpufreq driver.
+in the empty state described in {ref}`sec-device-fill-state` and bound to the
+uio-pci-generic user space driver. The CPU used the intel_cpufreq driver.
 
-### Empty vs. Populated Block Devices
-
-In this work, the goal is to measure the maximum IOPS the CPU and I/O stack are
-capable of driving. For this reason, benchmarks are executed against empty block
-devices. Using empty devices minimizes variability introduced by data layout,
-garbage collection, and background maintenance operations, allowing results to
-more directly reflect CPU scheduling, interrupt handling, and I/O submission and
-completion paths.
-
-While this methodology may produce IOPS figures that exceed those seen in real-
-world, data-bearing workloads, it provides a clearer upper bound on CPU-driven I/O
-capability. These results should therefore be interpreted as a measure of system
-overhead and scalability rather than as an indicator of application-level storage
-performance.
-
-Because of this, the theoretical device capacity for random reads of 3.2 million
-IOPS of the Samsung PM1753 is not applicable in these experiments. To determine a
-relevant cap, we use the maximum IOPS reached from any experiment using only one
-device. The determined capacity was only used in the analysis of the results to
-evaluate whether the benchmark was capped by the device, CPU, or the
-parameterization.
+Because the devices are empty, the theoretical device capacity for random reads
+of 3.2 million IOPS of the Samsung PM1753 is not applicable in these
+experiments. To determine a relevant cap, we use the maximum IOPS reached from
+any experiment using only one device. The determined capacity was only used in
+the analysis of the results to evaluate whether the benchmark was capped by the
+device, CPU, or the parameterization.
 
 ### Stressing Unused CPUs
 

--- a/docs/src/experiments/device_initiated_iosize.md
+++ b/docs/src/experiments/device_initiated_iosize.md
@@ -69,6 +69,9 @@ to user space drivers. The CPU governor is set to ``performance`` with turbo
 boost and SMT enabled. Each configuration is run five times and results are
 reported as arithmetic means.
 
+The namespaces are formatted before the run, as described in
+{ref}`sec-device-fill-state`.
+
 ## Execution of the Experiment
 
 Instructions for running ``bench_cuda_iosize.yaml`` are provided in

--- a/docs/src/experiments/device_initiated_iosize.md
+++ b/docs/src/experiments/device_initiated_iosize.md
@@ -113,7 +113,7 @@ The saturation queue depths are:
 
 At 64 KiB, a single queue depth of 2, 32 CUDA threads across 16 devices, is
 sufficient to sustain ~45 GB/s of storage bandwidth with no CPU involvement
-in the command path. ``qdepth=1`` still achieves 41.7 GB/s at this I/O size,
+in the command path. ``qdepth=1`` still achieves 41.9 GB/s at this I/O size,
 demonstrating that device-initiated I/O can approach the practical link ceiling
 with minimal thread-count overhead.
 
@@ -126,18 +126,37 @@ with minimal thread-count overhead.
 
 GPU engine activity vs. I/O size for xnvmeperf (cuda-run), 16 NVMe devices,
 nqueues=1, queue depth fixed at 128 (qdepth 128 × 16 devices = 2048 CUDA
-threads in total). SM active and SM
-occupancy (DCGM fields 1002/1003) measure the compute footprint of the
-persistent polling kernel; DRAM active (1005) tracks how much GPU memory
-bandwidth the P2P transfers consume.
+threads in total). SM active and SM occupancy are charted with each point
+carrying its reading; the SM clock (field 100) is on the right axis.
 ```
 
 The activity plot holds the queue depth at the largest configuration of the
-sweep and shows the GPU-side cost of driving the I/O across I/O sizes: unlike
-the CPU-initiated P2P path, the device-initiated path keeps a persistent kernel
-resident, so 1002/1003 quantify how much of the GPU's compute capacity the
-polling loop occupies while 1005 shows the memory-bandwidth share consumed by
-the incoming P2P writes.
+sweep, so what it charts across I/O sizes is the GPU-side cost of driving the
+I/O. Unlike the CPU-initiated P2P path, the device-initiated path keeps a
+persistent kernel resident.
+
+SM activity is flat at approximately 13.3% from 512 bytes to 64 KiB, and warp
+slot occupancy holds near 0.87%. Neither follows the work being done, since
+achieved bandwidth doubles across the sweep while the compute footprint moves by
+about two tenths of a percentage point. The cost follows the launch geometry
+instead. One resident block per queue per device is 16 blocks for the single
+queue per device this sweep uses, a footprint that stays flat however large the
+I/O. The queue-depth sweep confirms the reading by varying the queue count,
+which scales the footprint in proportion, as reported in
+{ref}`sec-experiments-cuda-qdepth-results`.
+
+DRAM activity stays at 0% up to 8 KiB and reaches only approximately 2.1% at the
+largest I/O sizes, so the data the SSDs read into GPU memory consumes a
+negligible share of HBM bandwidth and the constraint stays on the PCIe link
+rather than on GPU memory, as the CPU-initiated measurements in
+{ref}`sec-experiments-pcie-bandwidth-results` also found.
+
+Saturating the link through device-initiated I/O therefore costs roughly an
+eighth of the GPU's streaming multiprocessors and almost none of its memory
+bandwidth, leaving the remainder for the compute the data was fetched for. That
+eighth is the price of the single queue per device used throughout this sweep,
+and it is the queue count that moves it. The price of each further queue is
+reported in {ref}`sec-experiments-cuda-qdepth-results`.
 
 ### Run Validity
 

--- a/docs/src/experiments/device_initiated_iosize.md
+++ b/docs/src/experiments/device_initiated_iosize.md
@@ -25,10 +25,6 @@ in-flight commands are needed to fill the PCIe link. The minimum saturating
 queue depth is therefore expected to decrease as I/O size increases, revealing
 the thread count required at each I/O size.
 
-Hardware-level PCIe receive bandwidth is collected via DCGM alongside the
-application-level payload bandwidth reported by xnvmeperf, and a reference PCIe
-bandwidth measurement from ``nvbandwidth`` provides the practical ceiling.
-
 ## Independent Variables
 
 | Variable              | Parameter Set                                                |
@@ -45,22 +41,14 @@ bandwidth measurement from ``nvbandwidth`` provides the practical ceiling.
 | Metric                                   | Reported by                              |
 | ---------------------------------------- | ---------------------------------------- |
 | Payload bandwidth (GB/s)                 | xnvmeperf                                |
-| Total PCIe TX/RX bandwidth (bytes/s)     | DCGM fields 1009/1010 via ``dcgmi dmon`` |
 | SM activity (fraction of SMs occupied)   | DCGM field 1002 (SM_ACTIVE)              |
 | Warp slot occupancy                      | DCGM field 1003 (SM_OCCUPANCY)           |
 | GPU memory bandwidth utilization         | DCGM field 1005 (DRAM_ACTIVE)            |
-| Graphics engine activity                 | DCGM field 1001 (GR_ENGINE_ACTIVE)       |
-| SM/memory clocks, throttle reason bits   | DCGM fields 100/101/112                  |
+| SM clock                                 | DCGM field 100 (SM_CLOCK)                |
+| Run validity guards                      | DCGM fields 101/112/202/237/238          |
 | Host-to-device PCIe bandwidth (GB/s)     | ``nvbandwidth``                          |
 
-All DCGM fields are sampled every 100 ms by ``dcgmi dmon`` during the benchmark
-run and reported as mean/p95/min/max per field. The SM activity and occupancy
-fields (1002/1003) measure the GPU compute cost of the persistent polling
-kernel — the counterpart to the thread-count sweep. DRAM_ACTIVE (1005)
-discriminates bottlenecks: high PCIe RX with low DRAM_ACTIVE indicates a
-PCIe-bound run, while high DRAM_ACTIVE points to the GPU memory side. Fields
-100/101/112 are validity guards: runs where clocks dropped or throttling
-occurred are not comparable.
+The DCGM fields are collected as described in {ref}`sec-dcgm-sampling`.
 
 ## Environment
 
@@ -80,7 +68,7 @@ Instructions for running ``bench_cuda_iosize.yaml`` are provided in
 (sec-experiments-cuda-iosize-results)=
 ## Results
 
-Results are presented as PCIe RX bandwidth vs. I/O size, with one line per
+Results are presented as payload bandwidth vs. I/O size, with one line per
 queue depth (``qdepth`` ∈ { 1, 2, 4, 8, 16, 32, 64, 128 }). All configurations
 use **xnvmeperf** with the ``cuda-run`` subcommand and the **upcie-cuda**
 backend, ``nqueues=1``, and 16 NVMe devices. Total CUDA thread count equals
@@ -88,11 +76,11 @@ queue depth × 16. The dashed reference line marks the host-to-device PCIe
 bandwidth from ``nvbandwidth``.
 
 ```{figure} /lineplot-cuda-iosize.png
-:alt: PCIe RX bandwidth vs. I/O size for xnvmeperf (cuda-run) with varying queue depth
+:alt: Payload bandwidth vs. I/O size for xnvmeperf (cuda-run) with varying queue depth
 :width: 700px
 :align: center
 
-PCIe RX bandwidth vs. I/O size for xnvmeperf (cuda-run), 16 NVMe devices,
+Payload bandwidth vs. I/O size for xnvmeperf (cuda-run), 16 NVMe devices,
 nqueues=1. The minimum queue depth to saturate the ~45 GB/s practical ceiling
 drops from >128 at 512 B to 2 at 64 KiB.
 ```

--- a/docs/src/experiments/device_initiated_iosize.md
+++ b/docs/src/experiments/device_initiated_iosize.md
@@ -80,17 +80,12 @@ Instructions for running ``bench_cuda_iosize.yaml`` are provided in
 (sec-experiments-cuda-iosize-results)=
 ## Results
 
-The results below were collected before the reference measurement moved to
-``nvbandwidth`` and therefore quote the earlier ``p2pBandwidthLatencyTest``
-reference of 56.1 GB/s. They are restated against the ``nvbandwidth`` reference
-once the experiment has been re-run.
-
 Results are presented as PCIe RX bandwidth vs. I/O size, with one line per
 queue depth (``qdepth`` ∈ { 1, 2, 4, 8, 16, 32, 64, 128 }). All configurations
 use **xnvmeperf** with the ``cuda-run`` subcommand and the **upcie-cuda**
 backend, ``nqueues=1``, and 16 NVMe devices. Total CUDA thread count equals
-queue depth × 16. The dashed reference line marks the peak P2P bandwidth from
-``p2pBandwidthLatencyTest``.
+queue depth × 16. The dashed reference line marks the host-to-device PCIe
+bandwidth from ``nvbandwidth``.
 
 ```{figure} /lineplot-cuda-iosize.png
 :alt: PCIe RX bandwidth vs. I/O size for xnvmeperf (cuda-run) with varying queue depth
@@ -110,9 +105,9 @@ size increases, each command carries more payload, and the saturation threshold
 drops accordingly.
 
 All lines converge at a practical ceiling of approximately 44–45 GB/s, which
-falls roughly 80% of the way to the 56.1 GB/s ``p2pBandwidthLatencyTest``
-reference. This gap is consistent with the overhead of NVMe command processing
-and PCIe protocol framing on top of raw DMA throughput, as characterized in
+falls roughly 84% of the way to the 53.7 GB/s ``nvbandwidth`` reference. This
+gap is consistent with the overhead of NVMe command processing and PCIe
+protocol framing on top of raw DMA throughput, as characterized in
 {ref}`sec-experiments-pcie-bandwidth-results`.
 
 The saturation queue depths are:

--- a/docs/src/experiments/device_initiated_iosize.md
+++ b/docs/src/experiments/device_initiated_iosize.md
@@ -139,6 +139,14 @@ resident, so 1002/1003 quantify how much of the GPU's compute capacity the
 polling loop occupies while 1005 shows the memory-bandwidth share consumed by
 the incoming P2P writes.
 
+### Run Validity
+
+Between 73% and 77% of each monitoring window qualified as transferring.
+
+The guard fields agree that the runs are comparable. The SM and memory clocks
+hold at 1755 MHz and 1593 MHz with the throttle reason bits clear, the replay
+counter stays at zero, and the link fields report Gen5 x16 throughout.
+
 ## Summary
 
 The minimum thread count required to saturate the PCIe link decreases

--- a/docs/src/experiments/device_initiated_qdepth.md
+++ b/docs/src/experiments/device_initiated_qdepth.md
@@ -62,6 +62,7 @@ The namespaces are formatted before the run, as described in
 Instructions for running ``bench_cuda_qdepth.yaml`` are provided in
 {ref}`sec-experimental-framework`.
 
+(sec-experiments-cuda-qdepth-results)=
 ## Results
 
 Results are presented as IOPS vs. queue depth, with one line per number of
@@ -76,19 +77,19 @@ devices, and 512-byte I/O.
 
 IOPS vs. queue depth for xnvmeperf (cuda-run), 16 NVMe devices, 512 B I/O.
 All nqueues ≥ 2 configurations reach the 61.7 M IOPS roofline at qdepth=128;
-nqueues=1 reaches only 86.6% (53.5 M IOPS) at qdepth=512.
+nqueues=1 reaches only 86.7% (53.5 M IOPS) at qdepth=512.
 ```
 
 The results reveal a sharp divide between single-queue and multi-queue
 operation. With ``nqueues=1``, IOPS scales sub-linearly with queue depth and
-fails to saturate the device even at ``qdepth=512`` (53.5 M IOPS, 86.6% of the
+fails to saturate the devices even at ``qdepth=512`` (53.5 M IOPS, 86.7% of the
 61.7 M roofline). All multi-queue configurations (``nqueues`` ≥ 2) saturate the
-device completely, converging to ~61.5 M IOPS with very low variance once the
+devices completely, converging to ~61.5 M IOPS with very low variance once the
 threshold queue depth is reached. At ``qdepth=128``, ``nqueues=2`` delivers 61.5
-M IOPS. This is a 47% gain over the 41.9 M achieved by ``nqueues=1`` at the same
+M IOPS. This is a 45% gain over the 42.4 M achieved by ``nqueues=1`` at the same
 depth. Further queue doublings yield no measurable improvement.
 
-The minimum queue depth required to saturate the device varies by ``nqueues``:
+The minimum queue depth required to saturate the devices varies by ``nqueues``:
 
 | ``nqueues`` | Min. ``qdepth`` to saturate | Total CUDA threads |
 | ----------- | --------------------------- | ------------------ |
@@ -100,34 +101,120 @@ The minimum queue depth required to saturate the device varies by ``nqueues``:
 
 Total CUDA thread count is ``qdepth × nqueues × ndevs`` (16 devices).
 ``nqueues=2`` and ``nqueues=4`` are equally thread-efficient, both saturating
-the device at 4096 total threads. ``nqueues=8`` and ``nqueues=16`` reach
+the devices at 4096 total threads. ``nqueues=8`` and ``nqueues=16`` reach
 the roofline at the same ``qdepth=64`` but require 2× and 4× as many threads
 respectively for no throughput gain, making them suboptimal.
 
-``nqueues=4`` with ``qdepth=64`` represents the most practical configuration:
-it saturates the device at 4096 total threads, matching ``nqueues=2`` at
-``qdepth=128``, while requiring only half the per-queue depth, halving the
-number of commands in flight per queue.
+On thread count alone, ``nqueues=4`` with ``qdepth=64`` is as economical as
+``nqueues=2`` with ``qdepth=128``, since both saturate the devices at 4096 total
+threads and the former needs only half the per-queue depth, halving the number
+of commands in flight per queue. Thread count is not the only cost, however, and
+the activity results below separate the two.
 
 ### GPU Compute Cost of the Polling Kernel
 
+Queue depth and queue count both move SM activity and warp slot occupancy, so
+each field is charted across the whole grid, in the shape of the IOPS figure
+above. A ring marks the shallowest depth at which each queue count reaches the
+IOPS roofline, the depths tabulated above, so each figure carries the throughput
+its costs are weighed against. Any depth beyond a ring costs more without adding
+throughput.
+
 ```{figure} /lineplot-cuda-qdepth-sm.png
-:alt: GPU engine activity vs. queue depth for xnvmeperf (cuda-run) at nqueues=1
+:alt: SM activity vs. queue depth for xnvmeperf (cuda-run) with varying nqueues
 :width: 700px
 :align: center
 
-GPU engine activity vs. queue depth for xnvmeperf (cuda-run), 16 NVMe devices,
-512 B I/O, nqueues fixed at 1. SM active and SM occupancy (DCGM fields
-1002/1003) measure the compute footprint of the persistent polling kernel;
-DRAM active (1005) tracks the GPU memory bandwidth consumed by the incoming
-P2P writes.
+SM activity (DCGM field 1002) vs. queue depth for xnvmeperf (cuda-run), 16 NVMe
+devices, 512 B I/O. Each queue count holds a flat line across the depth sweep
+and the lines step up with the queue count, until ``nqueues=8`` and
+``nqueues=16`` come to rest on one another near 96%. ``nqueues=1`` carries no
+ring, since it never reaches the roofline at any depth. The number written on a
+line is a single reading from it; the table below gives the mean across the
+sweep.
 ```
 
-The activity plot holds ``nqueues`` at 1 so queue depth is the only variable:
-the total thread count (``qdepth × nqueues × ndevs``) grows from 16 threads at
-``qdepth=1`` to 8192 at ``qdepth=512`` along the x-axis, and fields 1002/1003
-show how much GPU compute capacity that polling footprint costs — the second
-result axis to weigh against the IOPS gained by deeper queues.
+```{figure} /lineplot-cuda-qdepth-occupancy.png
+:alt: Warp slot occupancy vs. queue depth for xnvmeperf (cuda-run) with varying nqueues
+:width: 700px
+:align: center
+
+Warp slot occupancy (DCGM field 1003) vs. queue depth for the same runs, on a
+log axis. The lines are flat out to ``qdepth=32`` and then climb in step,
+staying parallel. Each queue count that saturates the SSDs does so low on its
+climb, so the depth beyond that point is spent on warp slots alone.
+```
+
+No DRAM activity sample exceeds 1.7%, so at this I/O size the data the SSDs read
+into GPU memory places no meaningful load on it and neither figure is measuring
+one.
+
+Neither field follows the IOPS curve: what the polling kernel costs the GPU is
+set by how it is laid out across the device, not by how much I/O it completes.
+
+#### The Cost of a Queue
+
+Queue depth leaves the multiprocessor footprint untouched, but the queue count
+does not. SM activity holds the same value across the whole depth sweep at any
+given ``nqueues`` and doubles with each doubling of the queue count:
+
+| ``nqueues`` | Blocks (``nqueues × ndevs``) | SM active (depth-sweep mean) | IOPS at ``qdepth=128`` |
+| ----------- | --------------------------- | ---------------------------- | ---------------------- |
+| 1           | 16                          | 13.3%                        | 42.4 M                 |
+| 2           | 32                          | 26.8%                        | 61.5 M                 |
+| 4           | 64                          | 53.2%                        | 61.4 M                 |
+| 8           | 128                         | 95.7%                        | 61.4 M                 |
+| 16          | 256                         | 95.9%                        | 61.4 M                 |
+
+The activity column is the mean of each line over all ten queue depths, and no
+depth departs from its queue count's value by more than 1.7 percentage points.
+The
+IOPS column is quoted at ``qdepth=128``, where every multi-queue configuration
+has reached the roofline.
+
+This is the behaviour expected of one resident block per queue per device. Each
+configuration places ``nqueues × ndevs`` blocks on the GPU, and for as long as
+they fit on the multiprocessors available, each occupies one: the 16 blocks at
+``nqueues=1`` measure just under the 14.0% that 16 of the 114 multiprocessors
+would be, and the proportion holds through ``nqueues=4``. At ``nqueues=8`` the
+128 blocks outnumber the 114 multiprocessors, so activity saturates near 96% and
+the further doubling to 256 blocks adds nothing. The knee therefore falls where
+``nqueues × ndevs`` passes the multiprocessor count, not at any queue count in
+particular. With fewer multiprocessors on the GPU, or with more devices
+attached, fewer queues would reach it.
+
+#### The Cost of Queue Depth
+
+Queue depth is not paid for in multiprocessors but in warp slots, and both the
+flat part of the occupancy curve and the climb that follows come from one thread
+per outstanding command and a warp of 32 threads. While the queue is no deeper
+than a warp is wide, a block's commands fit within a single warp, so each of the
+``nqueues × ndevs`` blocks holds one warp slot however deep its queue, which is
+why the lines are flat out to ``qdepth=32``. Beyond it each doubling of the
+depth doubles the warps a block needs, the constant step the lines rise in.
+
+The lines stay parallel because queue depth and queue count enter the thread
+count as equal factors. Against the 7296 warp slots this GPU holds, 64 on each
+of its 114 multiprocessors, the span runs from 0.19% at a single queue and the
+shallowest depths to 53.9% at ``nqueues=16``, ``qdepth=512``.
+
+The two costs together price the saturating configuration. ``nqueues=2`` at
+``qdepth=128`` drives the SSDs to the 61.7 M IOPS roofline while the polling
+kernel holds **26.8% of the multiprocessors and 1.74% of the warp slots**. It is
+present on a quarter of the device and takes almost none of the capacity of what
+it sits on, so those multiprocessors stay open to another kernel being
+co-resident on them. The polling loop therefore interferes by
+presence rather than by exhaustion. A compute kernel sharing this GPU can still
+be given warp slots almost anywhere, but from ``nqueues=8`` upward it shares
+nearly every multiprocessor with a spinning poller. Depth becomes a
+cost in its own right only at the top right of the occupancy figure, where it
+reaches 26.9% and 53.9%, configurations that buy no throughput over
+``nqueues=2`` to begin with.
+
+This is what separates the two configurations the thread count left equivalent.
+``nqueues=4`` with ``qdepth=64`` and ``nqueues=2`` with ``qdepth=128`` are
+indistinguishable in warp slots, but the former holds half the multiprocessors
+where the latter holds a quarter.
 
 ### Run Validity
 
@@ -146,8 +233,24 @@ counter stays at zero, and the link fields report Gen5 x16 throughout.
 A single queue per device cannot saturate the devices at 512-byte I/O regardless
 of queue depth. Adding a second queue breaks this ceiling: ``nqueues=2`` with
 ``qdepth=128`` reaches the 61.7 M IOPS roofline at 4096 total threads, and
-``nqueues=4`` with ``qdepth=64`` matches this result with half the per-queue
-depth. Beyond ``nqueues=4``, additional queues increase thread count without
-improving throughput. Together with the I/O size scaling results, these findings
-characterize the thread count and queue configuration required to fully utilize
-device-initiated I/O across both the bandwidth-bound and IOPS-bound regimes.
+``nqueues=4`` with ``qdepth=64`` matches it on thread count with half the
+per-queue depth. Beyond ``nqueues=4``, additional queues increase thread count
+without improving throughput.
+
+The GPU-side cost separates the configurations that the IOPS curve leaves
+equivalent. The polling kernel occupies one multiprocessor per queue per device,
+so its footprint is set by the queue count alone and doubles with it, from 13.3%
+of the GPU at ``nqueues=1`` to 26.8% at 2 and 53.2% at 4, and effectively all of
+it from 8 upward, where the queues outnumber the multiprocessors. Queue depth is
+paid for in warp slots instead, which stay below 7% wherever a queue count first
+saturates the devices.
+
+Saturating the devices therefore costs 26.8% of the multiprocessors and 1.74% of
+the warp slots, at ``nqueues=2`` with ``qdepth=128``. That is half the GPU
+``nqueues=4`` costs for the same throughput, which makes ``nqueues=2`` the
+configuration to choose.
+
+Together with the I/O size scaling results, these findings characterize the
+thread count and queue configuration required to fully utilize device-initiated
+I/O across both the bandwidth-bound and IOPS-bound regimes, and what each
+configuration leaves of the GPU for the workload it feeds.

--- a/docs/src/experiments/device_initiated_qdepth.md
+++ b/docs/src/experiments/device_initiated_qdepth.md
@@ -56,6 +56,9 @@ to user space drivers. The CPU governor is set to ``performance`` with turbo
 boost and SMT enabled. Each configuration is run five times and results are
 reported as arithmetic means.
 
+The namespaces are formatted before the run, as described in
+{ref}`sec-device-fill-state`.
+
 ## Execution of the Experiment
 
 Instructions for running ``bench_cuda_qdepth.yaml`` are provided in

--- a/docs/src/experiments/device_initiated_qdepth.md
+++ b/docs/src/experiments/device_initiated_qdepth.md
@@ -42,12 +42,10 @@ first reaches device saturation.
 | SM activity (fraction of SMs occupied)   | DCGM field 1002 (SM_ACTIVE)              |
 | Warp slot occupancy                      | DCGM field 1003 (SM_OCCUPANCY)           |
 | GPU memory bandwidth utilization         | DCGM field 1005 (DRAM_ACTIVE)            |
+| SM clock                                 | DCGM field 100 (SM_CLOCK)                |
+| Run validity guards                      | DCGM fields 101/112/202/237/238          |
 
-The DCGM fields are sampled every 100 ms by ``dcgmi dmon`` during the benchmark
-run and reported as mean/p95/min/max per field. Since the total CUDA thread
-count grows with queue depth (``qdepth × nqueues × ndevs``), fields 1002/1003
-show how the compute footprint of the persistent polling kernel scales along
-the sweep.
+The DCGM fields are collected as described in {ref}`sec-dcgm-sampling`.
 
 ## Environment
 

--- a/docs/src/experiments/device_initiated_qdepth.md
+++ b/docs/src/experiments/device_initiated_qdepth.md
@@ -129,6 +129,18 @@ the total thread count (``qdepth × nqueues × ndevs``) grows from 16 threads at
 show how much GPU compute capacity that polling footprint costs — the second
 result axis to weigh against the IOPS gained by deeper queues.
 
+### Run Validity
+
+The transferring share of the monitoring window varies more across this sweep
+than any other, since setting up the queues takes longer the more of them there
+are: at ``qdepth=512`` it falls from 75% at ``nqueues=1`` to 12% at
+``nqueues=16``. Restricting the statistics to those samples is what keeps the
+means from describing the setup instead of the workload.
+
+The guard fields agree that the runs are comparable. The SM and memory clocks
+hold at 1755 MHz and 1593 MHz with the throttle reason bits clear, the replay
+counter stays at zero, and the link fields report Gen5 x16 throughout.
+
 ## Summary
 
 A single queue per device cannot saturate the devices at 512-byte I/O regardless

--- a/docs/src/experiments/pcie_saturation.md
+++ b/docs/src/experiments/pcie_saturation.md
@@ -74,11 +74,6 @@ runs affected by link downtraining (generation drop or lane reduction), and an
 increasing replay counter (202) flags retransmissions that reduce effective
 bandwidth — such runs must be excluded from the comparison.
 
-``nvbandwidth`` copies from host memory into GPU memory across the PCIe link of
-the GPU given by ``dcgm.gpu``, the same link the NVMe devices transfer over under
-P2P, which measures the peak bandwidth that link sustains. The value recorded is
-its ``host_to_device_memcpy_ce`` result.
-
 ## Environment
 
 The benchmarks were run on the {ref}`sec-env-hpc-server`. NVMe devices are bound to
@@ -97,11 +92,6 @@ Instructions for running ``bench_pcie.yaml`` are provided in
 (sec-experiments-pcie-bandwidth-results)=
 ## Results
 
-The results below were collected before the reference measurement moved to
-``nvbandwidth`` and therefore quote the earlier ``p2pBandwidthLatencyTest``
-reference of 56.1 GB/s. They are restated against the ``nvbandwidth`` reference
-once the experiment has been re-run.
-
 ```{figure} /barplot-sat.png
 :alt: Stacked bar chart of PCIe bandwidth by I/O size
 :width: 700px
@@ -112,8 +102,8 @@ NVMe SSDs transferring data P2P to a PCIe Gen5 GPU via the upcie-cuda backend.
 Each bar is stacked: the lower segment is the payload bandwidth reported by
 xnvmeperf; the upper segment is the remainder observed by DCGM. The dashed lines
 mark the PCIe line rate (64.0 GB/s for the Gen5 x16 link derived from the
-measured DCGM link fields 237/238) and the reference P2P bandwidth from
-``p2pBandwidthLatencyTest`` (56.1 GB/s). Result files that predate the link
+measured DCGM link fields 237/238) and the reference host-to-device bandwidth
+from ``nvbandwidth`` (53.3 GB/s). Result files that predate the link
 fields fall back to an assumed Gen5 x16 link, labelled ``(assumed)``.
 ```
 
@@ -129,7 +119,7 @@ NVMe command throughput, not PCIe link capacity.
 ### Large I/O: Link Approaches Saturation
 
 With 4096- and 8192-byte payloads, DCGM measures approximately 57.8 GB/s in both
-cases, exceeding the ``p2pBandwidthLatencyTest`` reference of 56.1 GB/s and
+cases, exceeding the ``nvbandwidth`` reference of 53.3 GB/s and
 reaching approximately 90% of the 64.0 GB/s line rate. The identical result at
 both I/O sizes indicates that the PCIe link, rather than NVMe command throughput,
 is the binding constraint at these I/O sizes. xnvmeperf reports approximately
@@ -152,7 +142,8 @@ characterization of the P2P data path regardless of operating regime.
 
 At small I/O sizes the P2P link operates far below capacity. At 4 KiB and above,
 a single CPU thread driving four NVMe devices is sufficient to push total PCIe
-traffic to approximately 57.8 GB/s, exceeding the practical P2P ceiling of
-56.1 GB/s and reaching approximately 90% of the Gen5 x16 line rate. Protocol
-overhead accounts for a consistent 28% above payload bandwidth across all tested
-I/O sizes, indicating it scales with bytes transferred rather than operation count.
+traffic to approximately 57.8 GB/s, exceeding the practical host-to-device
+ceiling of 53.3 GB/s and reaching approximately 90% of the Gen5 x16 line rate.
+Protocol overhead accounts for a consistent 28% above payload bandwidth across
+all tested I/O sizes, indicating it scales with bytes transferred rather than
+operation count.

--- a/docs/src/experiments/pcie_saturation.md
+++ b/docs/src/experiments/pcie_saturation.md
@@ -115,6 +115,20 @@ with a single CPU thread and only four NVMe devices, demonstrating that the
 uPCIe-cuda path requires minimal CPU and device resources to fully utilize the
 PCIe link at larger I/O sizes.
 
+### Run Validity
+
+As expected, SM_ACTIVE (1002) is 0.0% at every I/O size, confirming that the
+CPU-initiated P2P path consumes no GPU compute.
+
+Between 78% and 81% of each monitoring window qualified as transferring.
+DRAM_ACTIVE (1005) stays below 0.002% on average and peaks at 0.1%, so the HBM
+write drain is nowhere near a constraint and the limit sits on the link.
+
+The guard fields agree that the runs are comparable. The SM and memory clocks
+hold at 1755 MHz and 1593 MHz with the throttle reason bits clear, the replay
+counter stays at zero, and the link fields (237/238) report Gen5 x16 throughout,
+which confirms the 64.0 GB/s line rate.
+
 ### PCIe Protocol Overhead
 
 Across all three I/O sizes, the total PCIe receive bandwidth measured by DCGM

--- a/docs/src/experiments/pcie_saturation.md
+++ b/docs/src/experiments/pcie_saturation.md
@@ -86,6 +86,9 @@ user space drivers. The CPU governor is set to ``performance`` with turbo boost 
 SMT enabled. Each configuration is run five times and results are reported as
 arithmetic means.
 
+The namespaces are formatted before the run, as described in
+{ref}`sec-device-fill-state`.
+
 ## Execution of the Experiment
 
 Instructions for running ``bench_pcie.yaml`` are provided in

--- a/docs/src/experiments/pcie_saturation.md
+++ b/docs/src/experiments/pcie_saturation.md
@@ -23,7 +23,8 @@ This experiment fixes CPU threads at 1 and devices at 4, then sweeps I/O size
 across three points (512, 4096, and 8192 bytes), measuring both the payload
 bandwidth reported by xnvmeperf and the total PCIe receive traffic observed by
 DCGM at the GPU endpoint. The gap between the two reveals the share of the link
-consumed by NVMe and PCIe protocol traffic rather than payload. A reference
+consumed by NVMe and PCIe protocol traffic rather than payload: Submission and
+Completion Queue Entries, PRP list transfers, and framing. A reference
 host-to-device bandwidth from ``nvbandwidth`` establishes the practical ceiling
 of the link under sustained transfers into GPU memory.
 
@@ -50,29 +51,14 @@ link (64 GB/s line rate) rather than leave it underutilized.
 | Metric                                   | Reported by                              |
 | ---------------------------------------- | ---------------------------------------- |
 | Payload bandwidth (GB/s)                 | xnvmeperf                                |
-| Total PCIe TX/RX bandwidth (bytes/s)     | DCGM fields 1009/1010 via ``dcgmi dmon`` |
-| GPU memory bandwidth utilization         | DCGM field 1005 (DRAM_ACTIVE)            |
+| PCIe RX bandwidth (bytes/s)              | DCGM field 1010 (PCIE_RX_BYTES)          |
 | SM activity (fraction of SMs occupied)   | DCGM field 1002 (SM_ACTIVE)              |
+| GPU memory bandwidth utilization         | DCGM field 1005 (DRAM_ACTIVE)            |
 | PCIe link generation and width           | DCGM fields 237/238                      |
-| PCIe replay counter                      | DCGM field 202                           |
+| Run validity guards                      | DCGM fields 100/101/112/202              |
 | Host-to-device PCIe bandwidth (GB/s)     | ``nvbandwidth``                          |
 
-DCGM field 1010 counts PCIe receive bytes per second at the GPU endpoint, capturing
-all PCIe traffic directed to the GPU including NVMe payload, NVMe Submission Queue
-Entries, Completion Queue Entries, and PRP list transfers; field 1009 counts the
-opposite direction (GPU to host: completions and doorbell responses). All DCGM
-fields are sampled every 100 ms during the benchmark run and reported as
-mean/p95/min/max per field. **xnvmeperf** reports payload bytes per second based
-on completed I/O operations and their requested sizes.
-
-Since the CPU submits the I/O in this experiment and no GPU kernel runs,
-SM_ACTIVE (1002) is expected at ~0 and serves as measured evidence that the
-CPU-initiated P2P path consumes no GPU compute resources. DRAM_ACTIVE (1005)
-shows whether HBM write drain has headroom at the saturation point, separating
-"the link is the limit" from "GPU memory is the limit". Fields 237/238 identify
-runs affected by link downtraining (generation drop or lane reduction), and an
-increasing replay counter (202) flags retransmissions that reduce effective
-bandwidth — such runs must be excluded from the comparison.
+The DCGM fields are collected as described in {ref}`sec-dcgm-sampling`.
 
 ## Environment
 
@@ -100,7 +86,9 @@ Instructions for running ``bench_pcie.yaml`` are provided in
 PCIe RX bandwidth by NVMe command data payload size, measured with 4 PCIe Gen5
 NVMe SSDs transferring data P2P to a PCIe Gen5 GPU via the upcie-cuda backend.
 Each bar is stacked: the lower segment is the payload bandwidth reported by
-xnvmeperf; the upper segment is the remainder observed by DCGM. The dashed lines
+xnvmeperf; the upper segment is the remainder observed by DCGM, taken as the p95
+of field 1010 rather than the mean, since the transferring samples include the
+ramp up. The dashed lines
 mark the PCIe line rate (64.0 GB/s for the Gen5 x16 link derived from the
 measured DCGM link fields 237/238) and the reference host-to-device bandwidth
 from ``nvbandwidth`` (53.3 GB/s). Result files that predate the link

--- a/docs/src/experiments/pcie_saturation.md
+++ b/docs/src/experiments/pcie_saturation.md
@@ -91,8 +91,7 @@ of field 1010 rather than the mean, since the transferring samples include the
 ramp up. The dashed lines
 mark the PCIe line rate (64.0 GB/s for the Gen5 x16 link derived from the
 measured DCGM link fields 237/238) and the reference host-to-device bandwidth
-from ``nvbandwidth`` (53.3 GB/s). Result files that predate the link
-fields fall back to an assumed Gen5 x16 link, labelled ``(assumed)``.
+from ``nvbandwidth`` (53.3 GB/s).
 ```
 
 ### Small I/O: Link Underutilized
@@ -111,7 +110,7 @@ cases, exceeding the ``nvbandwidth`` reference of 53.3 GB/s and
 reaching approximately 90% of the 64.0 GB/s line rate. The identical result at
 both I/O sizes indicates that the PCIe link, rather than NVMe command throughput,
 is the binding constraint at these I/O sizes. xnvmeperf reports approximately
-45.2 GB/s of payload bandwidth for both sizes. This saturation is achieved
+45 GB/s of payload bandwidth at both sizes. This saturation is achieved
 with a single CPU thread and only four NVMe devices, demonstrating that the
 uPCIe-cuda path requires minimal CPU and device resources to fully utilize the
 PCIe link at larger I/O sizes.
@@ -134,4 +133,5 @@ traffic to approximately 57.8 GB/s, exceeding the practical host-to-device
 ceiling of 53.3 GB/s and reaching approximately 90% of the Gen5 x16 line rate.
 Protocol overhead accounts for a consistent 28% above payload bandwidth across
 all tested I/O sizes, indicating it scales with bytes transferred rather than
-operation count.
+operation count. Throughout, SM activity remains at zero, so the path reaches
+this bandwidth without consuming any GPU compute.

--- a/docs/src/experiments/tool_comparison.md
+++ b/docs/src/experiments/tool_comparison.md
@@ -125,6 +125,9 @@ drivers. The CPU governor is set to ``performance`` with turbo boost and SMT
 enabled. Each benchmark configuration is run five times and results are reported
 as arithmetic means.
 
+The namespaces are formatted before the run, as described in
+{ref}`sec-device-fill-state`.
+
 The independent variables are:
 
 | Variable              | Parameter Set                                                             |

--- a/docs/tooling/aisio_docs.py
+++ b/docs/tooling/aisio_docs.py
@@ -143,7 +143,8 @@ def make_plots(build_dir: str) -> None:
 
     with plots.artifacts_from_archive(artifacts / "device-initiated-qdepth.tar.gz") as archive:
         plots.lineplot(archive, build_dir, "cuda", "qdepth", colormap="plasma")
-        plots.lineplot(archive, build_dir, "cuda", "qdepth-sm")
+        plots.lineplot(archive, build_dir, "cuda", "qdepth-sm", colormap="plasma")
+        plots.lineplot(archive, build_dir, "cuda", "qdepth-occupancy", colormap="plasma")
 
 # ---------------------------------------------------------------------------
 # Extract latex_documents from latex_theme.py

--- a/docs/tooling/plots.py
+++ b/docs/tooling/plots.py
@@ -5,6 +5,7 @@
 import re
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.ticker import LogLocator, ScalarFormatter
 import tarfile
 import tempfile
 import yaml
@@ -324,7 +325,20 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
         ax.axhline(y=val, color=r["color"], linestyle=r["style"], linewidth=1.5,
                 label=f"{r['name']} ({roofline_label(val)})", zorder=1)
         ymax = max(ymax, val)
-    ax.set_ylim(0, ymax * 1.15)
+
+    # A quantity spanning orders of magnitude is charted on a log axis, where a
+    # constant factor between points reads as a constant step wherever it falls.
+    # Its decades are labelled as plain numbers, in the unit the axis is named
+    # for, and it takes the limits matplotlib derives from the data since a log
+    # axis cannot start at zero.
+    if cfg.get("yscale") == "log":
+        ax.set_yscale("log")
+        ax.yaxis.set_major_formatter(ScalarFormatter())
+        ax.yaxis.set_minor_locator(LogLocator(base=10, subs=(0.2, 0.5)))
+        ax.yaxis.set_minor_formatter(ScalarFormatter())
+        ax.tick_params(axis="y", which="minor", labelsize=7)
+    else:
+        ax.set_ylim(0, ymax * 1.15)
 
     # Legends sit on the half of the axes the series leave free: a plot whose
     # data hugs the bottom gets them on top. A figure whose free space is a

--- a/docs/tooling/plots.py
+++ b/docs/tooling/plots.py
@@ -5,10 +5,12 @@
 import re
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.colors import to_rgb
 from matplotlib.ticker import LogLocator, ScalarFormatter
 import tarfile
 import tempfile
 import yaml
+from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -23,6 +25,9 @@ def artifacts_from_archive(archive: Path):
         yield artifacts
 
 COLOR_SCHEME = [ "#2171b5", "#6baed6", "#9ecae1", "#fb6a4a", "#fcae91", "#ba381a" ]
+# A point carries its value when it stands this far clear of the last one
+# labelled, as a share of that reading.
+POINT_LABEL_STEP = 0.15
 LABEL_PP = {
     "spdk_bdevperf": "bdevperf (SPDK)",
     "spdk_nvme_perf": "nvmeperf (SPDK)",
@@ -284,15 +289,52 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
             pass
 
     data_max = 0
+    # The scaled readings each series draws, kept for the point labels below so
+    # the figure reads one set of values in one unit.
+    plotted = {}
     for group, color in zip(groups, colors):
         data = np.array([b.get(group, np.nan) for b in bars], dtype=float) / scale
         std = np.array([b.get(f"{group}_std", np.nan) for b in bars], dtype=float) / scale
         label = group.replace("_", " ")
         data_max = max(data_max, float(np.nanmax(data + std)))
+        plotted[group] = data
 
         ax.fill_between(x, data - std, data + std, alpha=0.15, color=color)
         ax.plot(x, data, color=color, linewidth=2, marker="o", markersize=4,
                 label=label)
+
+    # Values written onto the points, for a figure whose exact readings matter
+    # as much as the shape it draws. A point is labelled when it says something
+    # the last labelled one did not, so a flat line carries a single number and
+    # a climbing one is labelled at every step it takes.
+    if cfg.get("point_labels"):
+        placed = defaultdict(list)
+        for group, color in zip(groups, colors):
+            # A number is written in a darkened cast of its series colour, which
+            # keeps it readable at the light end of a palette while still
+            # belonging to its line.
+            text_color = [channel * 0.62 for channel in to_rgb(color)]
+            last = None
+            for idx, value in enumerate(plotted[group]):
+                if np.isnan(value):
+                    continue
+                if last is not None and abs(value - last) <= POINT_LABEL_STEP * abs(last):
+                    continue
+                # Series lying on top of one another would stack their numbers
+                # illegibly, so the first one placed speaks for them. The
+                # series it speaks for keeps looking for a step of its own,
+                # since nothing of it has been written down yet.
+                if any(abs(value - was) <= POINT_LABEL_STEP * abs(was)
+                       for was in placed[idx]):
+                    continue
+                last = value
+                placed[idx].append(value)
+                # Every number sits above its own point: a series labelled below
+                # would meet the number belonging to the series beneath it.
+                ax.annotate(f"{value:.2f}" if value < 1 else f"{value:.1f}",
+                            (idx, value), textcoords="offset points", xytext=(0, 7),
+                            ha="center", fontsize=7.5, fontweight="bold", zorder=6,
+                            color=text_color)
 
     ax2 = None
     if y2groups:

--- a/docs/tooling/plots.py
+++ b/docs/tooling/plots.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import to_rgb
 from matplotlib.lines import Line2D
+from matplotlib.patches import Rectangle
 from matplotlib.ticker import LogLocator, ScalarFormatter
 import tarfile
 import tempfile
@@ -216,12 +217,20 @@ def _sort_groups_numeric(groups):
     return groups
 
 
+def _colormap_colors(cmap, n):
+    """Return n colors spread across the readable span of a colormap."""
+    # A lone series has no span to spread across, so it takes the middle of the
+    # ramp rather than either extreme.
+    if n < 2:
+        return [cmap(0.5)] * n
+    return [cmap(0.1 + 0.8 * i / (n - 1)) for i in range(n)]
+
+
 def _line_colors(n):
     """Return n colors: use COLOR_SCHEME for small n, plasma for larger sets."""
     if n <= len(COLOR_SCHEME):
         return COLOR_SCHEME[:n]
-    cmap = plt.cm.plasma
-    return [cmap(0.1 + 0.8 * i / (n - 1)) for i in range(n)]
+    return _colormap_colors(plt.cm.plasma, n)
 
 
 def _fmt_bytes(val):
@@ -271,9 +280,7 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
     y2groups = [group for group in cfg.get("y2series", []) if group in groups]
     groups = [group for group in groups if group not in y2groups]
     if colormap:
-        cmap = plt.get_cmap(colormap)
-        n = len(groups)
-        colors = [cmap(0.1 + 0.8 * i / (n - 1)) for i in range(n)]
+        colors = _colormap_colors(plt.get_cmap(colormap), len(groups))
     else:
         colors = _line_colors(len(groups))
 
@@ -289,7 +296,6 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
         except (ValueError, TypeError):
             pass
 
-    data_max = 0
     # The scaled readings each series draws, kept for the mark and the point
     # labels below so the figure reads one set of values in one unit.
     plotted = {}
@@ -297,7 +303,6 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
         data = np.array([b.get(group, np.nan) for b in bars], dtype=float) / scale
         std = np.array([b.get(f"{group}_std", np.nan) for b in bars], dtype=float) / scale
         label = group.replace("_", " ")
-        data_max = max(data_max, float(np.nanmax(data + std)))
         plotted[group] = data
 
         ax.fill_between(x, data - std, data + std, alpha=0.15, color=color)
@@ -383,8 +388,8 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
             ax2.fill_between(x, data - std, data + std, alpha=0.15, color=color)
             ax2.plot(x, data, color=color, linewidth=2, marker="s", markersize=4,
                      linestyle="--", label=group.replace("_", " "))
-        # The headroom keeps the series clear of the legends, which sit at the
-        # top of the axes whenever the first axis leaves that half free.
+        # The headroom keeps the second axis's series clear of the legends,
+        # which sit wherever they cover least of what the figure draws.
         y2max = max(np.nanmax(np.array([b.get(g, np.nan) for b in bars], dtype=float))
                     for g in y2groups)
         ax2.set_ylim(0, float(y2max) * 1.35)
@@ -411,12 +416,11 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
     else:
         ax.set_ylim(0, ymax * 1.15)
 
-    # Legends sit on the half of the axes the series leave free: a plot whose
-    # data hugs the bottom gets them on top. A figure whose free space is a
-    # corner rather than a half names the placement itself.
-    vpos = "upper" if data_max < 0.5 * ax.get_ylim()[1] else "lower"
-    rooflines_loc = cfg.get("legend_rooflines", f"{vpos} left")
-    series_loc = cfg.get("legend_series", f"{vpos} right")
+    # Legends land where they cover the least of what is drawn, which matplotlib
+    # weighs against the series themselves. A figure that reads better with them
+    # somewhere particular names the placement itself.
+    rooflines_loc = cfg.get("legend_rooflines", "best")
+    series_loc = cfg.get("legend_series", "best")
 
     handles, labels_ = ax.get_legend_handles_labels()
     if ax2 is not None:
@@ -434,12 +438,35 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
         ref_handles.append(mark_handle)
         ref_labels.append(mark_handle.get_label())
 
-    leg1 = ax.legend(ref_handles, ref_labels,
-                     loc=rooflines_loc, fontsize=8, framealpha=0.9, edgecolor="#cccccc")
-    ax.add_artist(leg1)
+    # Series that all run flat across the full width leave no box-shaped gap
+    # anywhere in the axes, so such a figure lays its legend out in a single row
+    # and puts it in the headroom above the topmost series.
+    ncol = cfg.get("legend_series_ncol", 1)
+    if ncol == "row":
+        ncol = len(stack_idx)
+    series_leg = ax.legend(
+        [handles[i] for i in reversed(stack_idx)], [labels_[i] for i in reversed(stack_idx)],
+        loc=series_loc, ncol=ncol,
+        fontsize=8, framealpha=0.9, edgecolor="#cccccc")
+    ax.add_artist(series_leg)
 
-    ax.legend([handles[i] for i in reversed(stack_idx)], [labels_[i] for i in reversed(stack_idx)],
-              loc=series_loc, fontsize=8, framealpha=0.9, edgecolor="#cccccc")
+    # Matplotlib weighs a legend against the series but not against a legend
+    # already placed, so left to itself each one picks the same free corner and
+    # the two stack. Asking the series legend for its extent resolves where it
+    # chose to sit, which is then pinned so that fencing off the ground it took
+    # cannot move it again. The fence is an invisible patch, which the rooflines
+    # legend reads as occupied like any other drawn thing and so routes around,
+    # as it does the series.
+    if rooflines_loc == "best":
+        taken = series_leg.get_window_extent(fig.canvas.get_renderer())
+        fenced = taken.transformed(ax.transAxes.inverted())
+        series_leg.set_loc("lower left")
+        series_leg.set_bbox_to_anchor(fenced, transform=ax.transAxes)
+        ax.add_patch(Rectangle((fenced.x0, fenced.y0), fenced.width, fenced.height,
+                               alpha=0, transform=ax.transAxes))
+
+    ax.legend(ref_handles, ref_labels,
+              loc=rooflines_loc, fontsize=8, framealpha=0.9, edgecolor="#cccccc")
 
     plt.tight_layout()
     fig.subplots_adjust(top=0.83)

--- a/docs/tooling/plots.py
+++ b/docs/tooling/plots.py
@@ -65,6 +65,15 @@ def mathtt(s: str):
     return "".join(out)
 
 
+def fit_to_width(fig, text, max_frac=0.98, min_size=8):
+    """Shrink a figure-level text until it fits across the canvas."""
+    limit = max_frac * fig.get_size_inches()[0] * fig.dpi
+    renderer = fig.canvas.get_renderer()
+    while (text.get_fontsize() > min_size
+           and text.get_window_extent(renderer).width > limit):
+        text.set_fontsize(text.get_fontsize() - 0.5)
+
+
 def setup_figure(cfg):
     labels = [LABEL_PP.get(b["label"], b["label"]) for b in cfg["bars"]]
     fig, ax = plt.subplots(figsize=(8, 5))
@@ -85,9 +94,10 @@ def setup_figure(cfg):
     main_title = mathtt(title_lines[0])
     subtitle = mathtt("\n".join(title_lines[1:]))
 
-    fig.suptitle(main_title, fontsize=11, fontweight="bold", y=0.97)
+    fit_to_width(fig, fig.suptitle(main_title, fontsize=11, fontweight="bold", y=0.97))
     if subtitle.strip():
-        fig.text(0.5, 0.92, subtitle, ha="center", va="top", fontsize=9, color="#555555")
+        fit_to_width(fig, fig.text(0.5, 0.92, subtitle, ha="center", va="top",
+                                   fontsize=9, color="#555555"))
 
     if cfg.get("footnote"):
         footnote = mathtt(cfg["footnote"])

--- a/docs/tooling/plots.py
+++ b/docs/tooling/plots.py
@@ -6,6 +6,7 @@ import re
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import to_rgb
+from matplotlib.lines import Line2D
 from matplotlib.ticker import LogLocator, ScalarFormatter
 import tarfile
 import tempfile
@@ -289,8 +290,8 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
             pass
 
     data_max = 0
-    # The scaled readings each series draws, kept for the point labels below so
-    # the figure reads one set of values in one unit.
+    # The scaled readings each series draws, kept for the mark and the point
+    # labels below so the figure reads one set of values in one unit.
     plotted = {}
     for group, color in zip(groups, colors):
         data = np.array([b.get(group, np.nan) for b in bars], dtype=float) / scale
@@ -302,6 +303,34 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
         ax.fill_between(x, data - std, data + std, alpha=0.15, color=color)
         ax.plot(x, data, color=color, linewidth=2, marker="o", markersize=4,
                 label=label)
+
+    # A marked point on a series, named by the x label it sits at, so a figure
+    # can carry a threshold its own y-axis does not show. A ring around the
+    # point leaves the series reading as one line. A series without a mark is
+    # simply left unmarked.
+    marks = cfg.get("marks") or {}
+    mark_points = marks.get("points") or {}
+    positions = {str(b["label"]): idx for idx, b in enumerate(bars)}
+    marked = False
+    for group, color in zip(groups, colors):
+        at = mark_points.get(group)
+        if at is None:
+            continue
+        idx = positions.get(str(at))
+        if idx is None or np.isnan(plotted[group][idx]):
+            continue
+        ax.plot(idx, plotted[group][idx], linestyle="none", marker="o", markersize=11,
+                markerfacecolor="none", markeredgecolor=color, markeredgewidth=2.6,
+                zorder=5)
+        marked = True
+
+    # The legend names the mark once a series carries one, so a figure where no
+    # series reached the reference says nothing about it.
+    mark_handle = None
+    if marked:
+        mark_handle = Line2D([], [], linestyle="none", marker="o", markersize=9,
+                             markerfacecolor="none", markeredgecolor="#666666",
+                             markeredgewidth=2.6, label=marks.get("name", "marked"))
 
     # Values written onto the points, for a figure whose exact readings matter
     # as much as the shape it draws. A point is labelled when it says something
@@ -397,7 +426,15 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
     line_idx = [i for i, l in enumerate(labels_) if any(l.startswith(n) for n in line_labels)]
     stack_idx = [i for i in range(len(labels_)) if i not in line_idx]
 
-    leg1 = ax.legend([handles[i] for i in line_idx], [labels_[i] for i in line_idx],
+    # The rooflines legend also carries the mark, since both name a reference
+    # the series are read against rather than a series of their own.
+    ref_handles = [handles[i] for i in line_idx]
+    ref_labels = [labels_[i] for i in line_idx]
+    if mark_handle is not None:
+        ref_handles.append(mark_handle)
+        ref_labels.append(mark_handle.get_label())
+
+    leg1 = ax.legend(ref_handles, ref_labels,
                      loc=rooflines_loc, fontsize=8, framealpha=0.9, edgecolor="#cccccc")
     ax.add_artist(leg1)
 

--- a/docs/tooling/plots.py
+++ b/docs/tooling/plots.py
@@ -327,8 +327,11 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
     ax.set_ylim(0, ymax * 1.15)
 
     # Legends sit on the half of the axes the series leave free: a plot whose
-    # data hugs the bottom gets them on top.
+    # data hugs the bottom gets them on top. A figure whose free space is a
+    # corner rather than a half names the placement itself.
     vpos = "upper" if data_max < 0.5 * ax.get_ylim()[1] else "lower"
+    rooflines_loc = cfg.get("legend_rooflines", f"{vpos} left")
+    series_loc = cfg.get("legend_series", f"{vpos} right")
 
     handles, labels_ = ax.get_legend_handles_labels()
     if ax2 is not None:
@@ -339,11 +342,11 @@ def lineplot(artifacts, output, driver, xaxis="ncpus", colormap=None):
     stack_idx = [i for i in range(len(labels_)) if i not in line_idx]
 
     leg1 = ax.legend([handles[i] for i in line_idx], [labels_[i] for i in line_idx],
-                     loc=f"{vpos} left", fontsize=8, framealpha=0.9, edgecolor="#cccccc")
+                     loc=rooflines_loc, fontsize=8, framealpha=0.9, edgecolor="#cccccc")
     ax.add_artist(leg1)
 
     ax.legend([handles[i] for i in reversed(stack_idx)], [labels_[i] for i in reversed(stack_idx)],
-              loc=f"{vpos} right", fontsize=8, framealpha=0.9, edgecolor="#cccccc")
+              loc=series_loc, fontsize=8, framealpha=0.9, edgecolor="#cccccc")
 
     plt.tight_layout()
     fig.subplots_adjust(top=0.83)

--- a/scripts/dcgm_helper.py
+++ b/scripts/dcgm_helper.py
@@ -14,6 +14,23 @@ import logging as log
 PCIE_LANE_GBPS = {1: 0.25, 2: 0.5, 3: 1.0, 4: 2.0, 5: 4.0, 6: 8.0}
 
 
+def dcgm_stat(dcgm, field: str, stat: str = "mean"):
+    """
+    The named statistic a result recorded for a DCGM field, or None if it holds
+    none. Accepts both the per-run schema (stats are floats) and the combined
+    schema (stats are ``[avg, stddev]`` pairs); returns None for legacy scalar
+    entries and for fields the run did not monitor.
+    """
+    if not isinstance(dcgm, dict):
+        return None
+
+    stats = dcgm.get(field)
+    value = stats.get(stat) if isinstance(stats, dict) else None
+    if isinstance(value, (list, tuple)):
+        value = value[0]
+    return value
+
+
 def pcie_link_from_dcgm(dcgm) -> Optional[Tuple[int, int, float]]:
     """
     Derive ``(gen, width, line_rate_gbps)`` of the GPU's PCIe link from a
@@ -24,17 +41,8 @@ def pcie_link_from_dcgm(dcgm) -> Optional[Tuple[int, int, float]]:
     stat: ASPM parks the link at Gen1 while idle, so the maximum observed
     during a run is the operational link state.
     """
-    if not isinstance(dcgm, dict):
-        return None
-
-    def stat_max(field):
-        stats = dcgm.get(field)
-        value = stats.get("max") if isinstance(stats, dict) else None
-        if isinstance(value, (list, tuple)):
-            value = value[0]
-        return value
-
-    gen, width = stat_max("237"), stat_max("238")
+    gen = dcgm_stat(dcgm, "237", "max")
+    width = dcgm_stat(dcgm, "238", "max")
     if gen is None or width is None:
         return None
     gen, width = round(gen), round(width)

--- a/scripts/docs_plots_lineplot_cuda_iosize.py
+++ b/scripts/docs_plots_lineplot_cuda_iosize.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from cijoe.core.command import Cijoe
 from cijoe.core.resources import get_resources
 
+from dcgm_helper import dcgm_stat
 from version_helper import version_of
 
 
@@ -86,14 +87,12 @@ def collect(args, cijoe: Cijoe):
         if res["qdepth"] != SM_QDEPTH or not isinstance(dcgm, dict):
             continue
         for field, key in SM_FIELDS.items():
-            stats = dcgm.get(field)
-            value = stats.get("mean") if isinstance(stats, dict) else None
+            value = dcgm_stat(dcgm, field)
             if value is not None:
                 sm_data[res["iosize"]][key].append(value * 100)  # ratio -> %
 
         for field, key in STATE_FIELDS.items():
-            stats = dcgm.get(field)
-            value = stats.get("mean") if isinstance(stats, dict) else None
+            value = dcgm_stat(dcgm, field)
             if value is not None:
                 state_data[res["iosize"]][key].append(value)  # MHz
 

--- a/scripts/docs_plots_lineplot_cuda_iosize.py
+++ b/scripts/docs_plots_lineplot_cuda_iosize.py
@@ -32,12 +32,12 @@ REQ = {
 }
 
 # The GPU-activity plot holds queue depth fixed at the saturation point of
-# the bandwidth sweep.
+# the bandwidth sweep. It charts the two fields the polling kernel is paid for
+# in.
 SM_QDEPTH = 128
 SM_FIELDS = {
     "1002": "SM_active",
     "1003": "SM_occupancy",
-    "1005": "DRAM_active",
 }
 
 # The clock shares the sweep but not the unit of the activity fields, so it is

--- a/scripts/docs_plots_lineplot_cuda_qdepth.py
+++ b/scripts/docs_plots_lineplot_cuda_qdepth.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from cijoe.core.command import Cijoe
 from cijoe.core.resources import get_resources
 
+from dcgm_helper import dcgm_stat
 from version_helper import version_of
 
 
@@ -30,20 +31,25 @@ REQ = {
     "backend": "upcie-cuda",
 }
 
-# The GPU-activity plot holds the queue count fixed so the qdepth axis is the
-# only variable.
-SM_NQUEUES = 1
-SM_FIELDS = {
-    "1002": "SM_active",
-    "1003": "SM_occupancy",
-    "1005": "DRAM_active",
+# Queue depth and queue count both move SM activity and warp slot occupancy, so
+# each is charted over the whole grid rather than a slice of it: a figure per
+# field, drawn like the IOPS figure with the depth on the x-axis and one line
+# per queue count.
+ACTIVITY_FIGURES = {
+    "1002": "lineplot-cuda-qdepth-sm.yaml",
+    "1003": "lineplot-cuda-qdepth-occupancy.yaml",
 }
 
-# The clock shares the sweep but not the unit of the activity fields, so it is
-# charted against a second axis in MHz.
-STATE_FIELDS = {
-    "100": "SM_clock",
-}
+# The IOPS the devices deliver when the workload stops being the constraint,
+# determined in the CPU-initiated experiment. The figures draw it as a roofline
+# and the activity figures mark the point on each line that first reaches it.
+DEVICE_IOPS_ROOFLINE = 61727008
+
+# A configuration counts as saturating at the shallowest depth reaching this
+# share of the roofline. Queue counts above one arrive within a percent or two
+# of it and then stay, so the depth it selects is insensitive to the exact
+# share; a single queue never reaches it at any depth.
+SATURATION_SHARE = 0.98
 
 
 def add_args(parser: ArgumentParser):
@@ -66,37 +72,29 @@ def collect(args, cijoe: Cijoe):
     err, state = cijoe.run(" ".join(cmd))
     if err:
         log.error("Failed: jq")
-        return err, None, None, None, ""
+        return err, None, None, ""
 
     results = json_load(state.output())
     results.sort(key=lambda res: res["qdepth"])
     version = version_of(results)
     data = defaultdict(lambda: defaultdict(list))
-    sm_data = defaultdict(lambda: defaultdict(list))
-    state_data = defaultdict(lambda: defaultdict(list))
+    activity = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
 
     for res in results:
         data[res["qdepth"]][res["nqueues"]].append(res["iops"])
 
-        # GPU engine activity at the fixed queue count. "dcgm" is a
-        # per-field stats dict in new result files; None or a scalar in
-        # older ones, which then simply yield an empty activity plot.
+        # GPU engine activity. "dcgm" is a per-field stats dict in new result
+        # files; None or a scalar in older ones, which then simply yield an
+        # empty activity plot.
         dcgm = res.get("dcgm")
-        if res["nqueues"] != SM_NQUEUES or not isinstance(dcgm, dict):
+        if not isinstance(dcgm, dict):
             continue
-        for field, key in SM_FIELDS.items():
-            stats = dcgm.get(field)
-            value = stats.get("mean") if isinstance(stats, dict) else None
+        for field, name in ACTIVITY_FIGURES.items():
+            value = dcgm_stat(dcgm, field)
             if value is not None:
-                sm_data[res["qdepth"]][key].append(value * 100)  # ratio -> %
+                activity[name][res["qdepth"]][res["nqueues"]].append(value * 100)
 
-        for field, key in STATE_FIELDS.items():
-            stats = dcgm.get(field)
-            value = stats.get("mean") if isinstance(stats, dict) else None
-            if value is not None:
-                state_data[res["qdepth"]][key].append(value)  # MHz
-
-    return 0, data, sm_data, state_data, version
+    return 0, data, activity, version
 
 
 def avg_stddev(values):
@@ -105,6 +103,26 @@ def avg_stddev(values):
     avg = sum(values) / len(values)
     stddev = (sum((x - avg) ** 2 for x in values) / len(values)) ** 0.5
     return avg, stddev
+
+
+def saturating_depths(results):
+    """
+    The shallowest queue depth at which each queue count reaches the roofline.
+
+    Keyed by the series name the figures use, so a figure charting something
+    other than IOPS can still mark where the devices ran out of headroom. A
+    queue count that never reaches it is absent rather than marked.
+    """
+
+    floor = DEVICE_IOPS_ROOFLINE * SATURATION_SHARE
+    saturating = {}
+    for qdepth in sorted(results):
+        for nqueues, (iops, _) in sorted(results[qdepth].items()):
+            series = f"nqueues_{nqueues}"
+            if series not in saturating and iops >= floor:
+                saturating[series] = qdepth
+
+    return saturating
 
 
 def main(args, cijoe):
@@ -124,7 +142,7 @@ def main(args, cijoe):
     template_env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
     template = template_env.get_template(f"{template_name}.jinja2")
 
-    err, results, sm_results, state_results, version = collect(args, cijoe)
+    err, results, activity, version = collect(args, cijoe)
     if err:
         log.error("Failed: collect()")
         return err
@@ -137,22 +155,24 @@ def main(args, cijoe):
     with out_path.open("w") as body:
         body.write(template.render({
             "results": results,
+            "device_roofline": DEVICE_IOPS_ROOFLINE,
             "xnvme_version": version,
         }))
 
-    charted = defaultdict(dict)
-    for qdepth in sorted(set(sm_results) | set(state_results)):
-        for metrics in (sm_results.get(qdepth, {}), state_results.get(qdepth, {})):
-            for key, values in metrics.items():
-                charted[qdepth][key] = [round(v, 2) for v in avg_stddev(values)]
+    saturating = saturating_depths(results)
 
-    sm_template_name = "lineplot-cuda-qdepth-sm.yaml"
-    sm_template = template_env.get_template(f"{sm_template_name}.jinja2")
-    out_path = artifacts / sm_template_name
-    with out_path.open("w") as body:
-        body.write(sm_template.render({
-            "results": charted,
-            "xnvme_version": version,
-        }))
+    for name, grid in activity.items():
+        charted = defaultdict(dict)
+        for qdepth in sorted(grid):
+            for nqueues, values in sorted(grid[qdepth].items()):
+                charted[qdepth][nqueues] = [round(v, 2) for v in avg_stddev(values)]
+
+        out_path = artifacts / name
+        with out_path.open("w") as body:
+            body.write(template_env.get_template(f"{name}.jinja2").render({
+                "results": charted,
+                "saturating": saturating,
+                "xnvme_version": version,
+            }))
 
     return 0

--- a/templates/lineplot-cuda-iosize-sm.yaml.jinja2
+++ b/templates/lineplot-cuda-iosize-sm.yaml.jinja2
@@ -11,10 +11,14 @@ title: |
 xlabel: I/O Size (bytes)
 ylabel: GPU engine activity (%)
 y2label: SM clock (MHz)
-footnote: DCGM fields 100/1002/1003/1005 via dcgmi dmon; the persistent I/O kernel polls NVMe completions from the GPU{% if xnvme_version %} | xNVMe {{ xnvme_version }}{% endif %}
+footnote: DCGM fields 100/1002/1003 via dcgmi dmon; the persistent I/O kernel polls NVMe completions from the GPU{% if xnvme_version %} | xNVMe {{ xnvme_version }}{% endif %}
 
 y2series:
 - SM_clock
+
+# Both fields hold a flat line an order of magnitude apart, so the readings the
+# section quotes are what the figure has to carry beyond that shape.
+point_labels: true
 
 rooflines:
 - name: Fully active

--- a/templates/lineplot-cuda-qdepth-activity.jinja2.yaml
+++ b/templates/lineplot-cuda-qdepth-activity.jinja2.yaml
@@ -1,0 +1,30 @@
+{#
+SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+
+SPDX-License-Identifier: BSD-3-Clause
+
+The readings and the saturation marks shared by the GPU-activity figures of the
+queue-depth sweep, which chart one DCGM field each over the same grid.
+-#}
+# Exact readings matter as much as the shape here, since the section quotes
+# them; a point carries its value when it differs from the last one labelled.
+point_labels: true
+
+# The point on each line where its queue count first drives the devices to their
+# IOPS roofline. Everything to the right of it costs more for no more
+# throughput; a queue count that never reaches the roofline carries no mark.
+marks:
+  name: SSDs saturated
+  points:
+    {%- for series, qdepth in saturating.items() %}
+    {{ series }}: "{{ qdepth }}"
+    {%- endfor %}
+
+bars:
+{%- for qdepth, series in results.items() %}
+- label: "{{ qdepth }}"
+  {%- for nqueues, result in series.items() %}
+  nqueues_{{ nqueues }}: {{ result[0] }}
+  nqueues_{{ nqueues }}_std: {{ result[1] }}
+  {%- endfor %}
+{% endfor %}

--- a/templates/lineplot-cuda-qdepth-occupancy.yaml.jinja2
+++ b/templates/lineplot-cuda-qdepth-occupancy.yaml.jinja2
@@ -1,0 +1,30 @@
+{#
+SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+
+SPDX-License-Identifier: BSD-3-Clause
+#}
+
+title: |
+  Warp slot occupancy when exercising a random-read workload using `xnvmeperf` with device-initiated I/O
+  16 PCIe Gen5 NVMe SSDs (BS 512, nqueues varied) via the `upcie-cuda` backend
+
+xlabel: Queue Depth
+ylabel: Warp slot occupancy (%)
+footnote: DCGM field 1003 via dcgmi dmon; the persistent I/O kernel polls NVMe completions from the GPU{% if xnvme_version %} | xNVMe {{ xnvme_version }}{% endif %}
+
+# Occupancy spans from a fraction of a percent to half the warp slots on the
+# device, so it is charted on a log axis, where the doubling it answers with
+# reads as a constant step at any point in that range.
+yscale: log
+
+# The series climb to the right, leaving the upper left and the floor free.
+legend_series: upper left
+legend_rooflines: lower right
+
+rooflines:
+- name: All warp slots
+  value_pct: 100
+  color: '#fb6a4a'
+  style: ':'
+
+{% include "lineplot-cuda-qdepth-activity.jinja2.yaml" %}

--- a/templates/lineplot-cuda-qdepth-sm.yaml.jinja2
+++ b/templates/lineplot-cuda-qdepth-sm.yaml.jinja2
@@ -5,16 +5,20 @@ SPDX-License-Identifier: BSD-3-Clause
 #}
 
 title: |
-  GPU engine activity during device-initiated random reads with `xnvmeperf`
-  16 PCIe Gen5 NVMe SSDs (BS 512, nqueues 1) via the `upcie-cuda` backend
+  SM activity when exercising a random-read workload using `xnvmeperf` with device-initiated I/O
+  16 PCIe Gen5 NVMe SSDs (BS 512, nqueues varied) via the `upcie-cuda` backend
 
 xlabel: Queue Depth
-ylabel: GPU engine activity (%)
-y2label: SM clock (MHz)
-footnote: DCGM fields 100/1002/1003/1005 via dcgmi dmon; the persistent I/O kernel polls NVMe completions from the GPU{% if xnvme_version %} | xNVMe {{ xnvme_version }}{% endif %}
+ylabel: SM active (%)
+footnote: DCGM field 1002 via dcgmi dmon; the persistent I/O kernel polls NVMe completions from the GPU{% if xnvme_version %} | xNVMe {{ xnvme_version }}{% endif %}
 
-y2series:
-- SM_clock
+# The series run flat across the whole width at the value their queue count
+# sets, leaving no gap in the axes that a stacked legend fits into. The series
+# legend is laid out as a single row and sits in the headroom above the topmost
+# series; the rooflines legend goes under the lowest one.
+legend_series: upper center
+legend_series_ncol: row
+legend_rooflines: lower left
 
 rooflines:
 - name: Fully active
@@ -22,11 +26,4 @@ rooflines:
   color: '#fb6a4a'
   style: ':'
 
-bars:
-{%- for qdepth, metrics in results.items() %}
-- label: "{{ qdepth }}"
-  {%- for key, result in metrics.items() %}
-  {{ key }}: {{ result[0] }}
-  {{ key }}_std: {{ result[1] }}
-  {%- endfor %}
-{% endfor %}
+{% include "lineplot-cuda-qdepth-activity.jinja2.yaml" %}

--- a/templates/lineplot-cuda-qdepth.yaml.jinja2
+++ b/templates/lineplot-cuda-qdepth.yaml.jinja2
@@ -14,7 +14,7 @@ footnote: Device-initiated I/O using the `cuda-run` subcommand; data buffers res
 
 rooflines:
 - name: Device IOPS Capacity
-  value_iops: 61727008
+  value_iops: {{ device_roofline }}
   color: '#fb6a4a'
   style: ':'
 


### PR DESCRIPTION
The published saturation, I/O size and queue-depth archives predate the DCGM
work on `main`. Their statistics averaged the whole monitoring window rather
than the transfer, they carried no engine activity, occupancy or clock fields,
and they recorded neither an `nvbandwidth` reference nor the link the run was
measured on. 

## What this does

Re-collects all three experiments on the current tooling, then follows the
results through the documentation.

The queue-depth experiment gains a second result axis: what the persistent
polling kernel costs the GPU. Its footprint turns out to follow the launch
geometry rather than the work it performs, which separates two configurations
the IOPS curve leaves equivalent and settles which one to choose when the GPU
also has to compute on the data it fetches. The I/O size experiment reports the
same cost across its sweep and can now point at the queue-depth sweep for the
variable that moves it.

Supporting changes to the plotting code, each landing before the figure that
needs it: a log axis, measured values written onto the points, a mark for where
a series reaches a reference, per-field activity figures charted over both
sweep variables, and figure-chosen legend placement.

The methodology sections say what the numbers rest on: the device fill state
every synthetic benchmark assumes and how to reach it, the DCGM statistics as
describing the transfer alone, the clock each activity reading was taken at, and
the reference each run measured for itself. The environment table records the
GPU the server now carries.

## NOTE
The changes to `plots.py` has an influence on multiple graphs. I highly encourage that you build the docs and check them while reviewing. There are too many to include here.